### PR TITLE
Add a common Error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+Added:
+- In case of argument errors, raise an `Actor::ArgumentError` instead of a
+  `ArgumentError`.
+- All errors inherit from `Actor::Error`.
+
 ## v1.1.0
 
 Added:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If an input does not have a default, it will raise a error:
 
 ```rb
 result = BuildGreeting.call
-=> ArgumentError: Input name on BuildGreeting is missing.
+=> Actor::ArgumentError: Input name on BuildGreeting is missing.
 ```
 
 ### Conditions

--- a/lib/actor/argument_error.rb
+++ b/lib/actor/argument_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Actor
+  # Raised when an input or output does not match the given conditions.
+  class ArgumentError < Actor::Error; end
+end

--- a/lib/actor/conditionable.rb
+++ b/lib/actor/conditionable.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class Actor
-  # Add boolean checks to inputs, by calling lambdas starting with `must*`.
+  # Add checks to your inputs, by calling lambdas with the name of you choice.
+  # Will raise an error if any check does return a truthy value.
   #
   # Example:
   #
@@ -10,8 +11,6 @@ class Actor
   #           must: {
   #             exist: ->(provider) { PROVIDERS.include?(provider) }
   #           }
-  #
-  #     output :user, required: true
   #   end
   module Conditionable
     def before
@@ -24,8 +23,7 @@ class Actor
           value = @context[key]
           next if check.call(value)
 
-          name = name.to_s.sub(/^must_/, '')
-          raise ArgumentError,
+          raise Actor::ArgumentError,
                 "Input #{key} must #{name} but was #{value.inspect}."
         end
       end

--- a/lib/actor/defaultable.rb
+++ b/lib/actor/defaultable.rb
@@ -16,7 +16,8 @@ class Actor
         next if @context.key?(name)
 
         unless input.key?(:default)
-          raise ArgumentError, "Input #{name} on #{self.class} is missing."
+          raise Actor::ArgumentError,
+                "Input #{name} on #{self.class} is missing."
         end
 
         default = input[:default]

--- a/lib/actor/error.rb
+++ b/lib/actor/error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Actor
+  # Standard exception from which other inherit.
+  class Error < StandardError; end
+end

--- a/lib/actor/failure.rb
+++ b/lib/actor/failure.rb
@@ -2,7 +2,7 @@
 
 class Actor
   # Error raised when using `fail!` inside an actor.
-  class Failure < StandardError
+  class Failure < Actor::Error
     def initialize(context)
       @context = context
 

--- a/lib/actor/filtered_context.rb
+++ b/lib/actor/filtered_context.rb
@@ -30,7 +30,8 @@ class Actor
     # rubocop:disable Style/MethodMissingSuper
     def method_missing(name, *arguments, &block)
       unless available_methods.include?(name)
-        raise ArgumentError, "Cannot call #{name} on #{inspect}"
+        raise Actor::ArgumentError,
+              "Cannot call #{name} on #{inspect}"
       end
 
       context.public_send(name, *arguments, &block)

--- a/lib/actor/nil_checkable.rb
+++ b/lib/actor/nil_checkable.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Actor
+  # Ensure your inputs and outputs are not nil by adding `allow_nil: false`.
+  #
+  # Example:
+  #
+  #   class CreateUser < Actor
+  #     input :name, allow_nil: false
+  #     output :user, allow_nil: false
+  #   end
+  module NilCheckable
+    def before
+      super
+
+      check_context_for_nil(self.class.inputs, origin: 'input')
+    end
+
+    def after
+      super
+
+      check_context_for_nil(self.class.outputs, origin: 'output')
+    end
+
+    private
+
+    def check_context_for_nil(definitions, origin:)
+      definitions.each do |key, options|
+        options = deprecated_required_option(options, name: key, origin: origin)
+
+        next unless @context[key].nil?
+        next unless options.key?(:allow_nil)
+        next if options[:allow_nil]
+
+        raise Actor::ArgumentError,
+              "The #{origin} \"#{key}\" on #{self.class} does not allow nil " \
+              'values.'
+      end
+    end
+
+    def deprecated_required_option(options, name:, origin:)
+      return options unless options.key?(:required)
+
+      warn 'DEPRECATED: The "required" option is deprecated. Replace ' \
+           "`#{origin} :#{name}, required: #{options[:required]}` by " \
+           "`#{origin} :#{name}, allow_nil: #{!options[:required]}` in " \
+           "#{self.class}."
+
+      options.merge(allow_nil: !options[:required])
+    end
+  end
+end

--- a/lib/actor/requireable.rb
+++ b/lib/actor/requireable.rb
@@ -28,7 +28,7 @@ class Actor
       definitions.each do |key, options|
         next unless options[:required] && @context[key].nil?
 
-        raise ArgumentError,
+        raise Actor::ArgumentError,
               "#{kind} #{key} on #{self.class} is required but was nil."
       end
     end

--- a/lib/actor/success.rb
+++ b/lib/actor/success.rb
@@ -2,5 +2,5 @@
 
 class Actor
   # Raised when using `succeed!` to halt the progression of an organizer.
-  class Success < StandardError; end
+  class Success < Actor::Error; end
 end

--- a/lib/actor/type_checkable.rb
+++ b/lib/actor/type_checkable.rb
@@ -34,9 +34,9 @@ class Actor
         types = Array(type_definition).map { |name| Object.const_get(name) }
         next if types.any? { |type| value.is_a?(type) }
 
-        error = "#{kind} #{key} on #{self.class} must be of type " \
-                "#{types.join(', ')} but was #{value.class}"
-        raise ArgumentError, error
+        raise Actor::ArgumentError,
+              "#{kind} #{key} on #{self.class} must be of type " \
+              "#{types.join(', ')} but was #{value.class}"
       end
     end
   end

--- a/lib/service_actor.rb
+++ b/lib/service_actor.rb
@@ -2,11 +2,17 @@
 
 require 'ostruct'
 
+# Exceptions
+require 'actor/error'
 require 'actor/failure'
 require 'actor/success'
+require 'actor/argument_error'
+
+# Context
 require 'actor/context'
 require 'actor/filtered_context'
 
+# Modules
 require 'actor/playable'
 require 'actor/attributable'
 require 'actor/defaultable'

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Actor do
       it 'raises an error' do
         expect { SetNameToDowncase.call }
           .to raise_error(
-            ArgumentError,
+            Actor::ArgumentError,
             'Input name on SetNameToDowncase is missing.',
           )
       end
@@ -198,7 +198,7 @@ RSpec.describe Actor do
         expected_error = 'Input name must be_lowercase but was "42".'
 
         expect { SetNameWithInputCondition.call(name: '42') }
-          .to raise_error(ArgumentError, expected_error)
+          .to raise_error(Actor::ArgumentError, expected_error)
       end
     end
 
@@ -206,7 +206,7 @@ RSpec.describe Actor do
       it 'raises with a message' do
         expect { SetNameToDowncase.call(name: 1) }
           .to raise_error(
-            ArgumentError,
+            Actor::ArgumentError,
             'Input name on SetNameToDowncase must be of type String but was ' \
               'Integer',
           )
@@ -217,7 +217,7 @@ RSpec.describe Actor do
       it 'raises with a message' do
         expect { SetWrongTypeOfOutput.call }
           .to raise_error(
-            ArgumentError,
+            Actor::ArgumentError,
             'Output name on SetWrongTypeOfOutput must be of type String but ' \
               'was Integer',
           )
@@ -233,14 +233,14 @@ RSpec.describe Actor do
     context 'when using an unknown input' do
       it 'raises with a message' do
         expect { UseUnknownInput.call }
-          .to raise_error(ArgumentError, /Cannot call foobar on/)
+          .to raise_error(Actor::ArgumentError, /Cannot call foobar on/)
       end
     end
 
     context 'when setting an unknown output' do
       it 'raises with a message' do
         expect { SetUnknownOutput.call }
-          .to raise_error(ArgumentError, /Cannot call foobar= on/)
+          .to raise_error(Actor::ArgumentError, /Cannot call foobar= on/)
       end
     end
 
@@ -255,7 +255,7 @@ RSpec.describe Actor do
             'Input name on UseRequiredInput is required but was nil.'
 
           expect { UseRequiredInput.call(name: nil) }
-            .to raise_error(ArgumentError, expected_error)
+            .to raise_error(Actor::ArgumentError, expected_error)
         end
       end
     end
@@ -271,7 +271,7 @@ RSpec.describe Actor do
             'Output name on SetWrongRequiredOutput is required but was nil.'
 
           expect { SetWrongRequiredOutput.call }
-            .to raise_error(ArgumentError, expected_error)
+            .to raise_error(Actor::ArgumentError, expected_error)
         end
       end
     end


### PR DESCRIPTION
All errors now inherit from a `Actor::Error`.

Originally suggested by [@nicoolas25](https://github.com/nicoolas25/actor/pull/1).