### PR TITLE
Remove default error output

### DIFF
--- a/lib/actor/attributable.rb
+++ b/lib/actor/attributable.rb
@@ -40,7 +40,7 @@ class Actor
       end
 
       def outputs
-        @outputs ||= { error: { type: 'String' } }
+        @outputs ||= {}
       end
     end
 


### PR DESCRIPTION
Since failures do not check for outputs, this doesn't need to be here.