### PR TITLE
Outputs add writer methods inside actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Added:
 - Outputs add writer methods inside your actors, so you can do `self.name =`
   instead of `context.name =`.
+- Outputs adds reader methods as well, so you can use anything you just set on
+  the context right away inside your actor.
 - Deprecate `required: true` in favor of `allow_nil: false`.
 - In case of argument errors, raise an `Actor::ArgumentError` instead of a
   `ArgumentError`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 Added:
+- Outputs add writer methods inside your actors, so you can do `self.name =`
+  instead of `context.name =`.
 - Deprecate `required: true` in favor of `allow_nil: false`.
 - In case of argument errors, raise an `Actor::ArgumentError` instead of a
   `ArgumentError`.

--- a/README.md
+++ b/README.md
@@ -352,6 +352,9 @@ However there are a few key differences which make `actor` unique:
 - No `before`, `after` and `around` hooks, prefer using `play` with lambdas or
   overriding `call`.
 
+Thank you to @nicoolas25, @AnneSottise & @williampollet for the early thoughts
+and feedback on this gem.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/lib/actor/attributable.rb
+++ b/lib/actor/attributable.rb
@@ -28,7 +28,7 @@ class Actor
           context.public_send(name)
         end
 
-        private name
+        protected name
       end
 
       def inputs
@@ -46,7 +46,7 @@ class Actor
           context.public_send("#{name}=", value)
         end
 
-        private name, "#{name}="
+        protected name, "#{name}="
       end
 
       def outputs

--- a/lib/actor/attributable.rb
+++ b/lib/actor/attributable.rb
@@ -45,6 +45,8 @@ class Actor
         define_method("#{name}=") do |value|
           context.public_send("#{name}=", value)
         end
+
+        private name, "#{name}="
       end
 
       def outputs

--- a/lib/actor/attributable.rb
+++ b/lib/actor/attributable.rb
@@ -37,6 +37,14 @@ class Actor
 
       def output(name, **arguments)
         outputs[name] = arguments
+
+        define_method(name) do
+          context.public_send(name)
+        end
+
+        define_method("#{name}=") do |value|
+          context.public_send("#{name}=", value)
+        end
       end
 
       def outputs

--- a/lib/actor/defaultable.rb
+++ b/lib/actor/defaultable.rb
@@ -22,7 +22,7 @@ class Actor
 
         default = input[:default]
         default = default.call if default.respond_to?(:call)
-        @context.merge!(name => default)
+        @context[name] = default
       end
 
       super

--- a/lib/actor/filtered_context.rb
+++ b/lib/actor/filtered_context.rb
@@ -44,7 +44,7 @@ class Actor
 
     def available_methods
       @available_methods ||=
-        readers + setters.map { |key| "#{key}=".to_sym }
+        readers + setters + setters.map { |key| "#{key}=".to_sym }
     end
   end
 end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -211,9 +211,9 @@ RSpec.describe Actor do
     end
 
     context 'when setting an unknown output' do
-      it 'raises with a message' do
+      it 'raises' do
         expect { SetUnknownOutput.call }
-          .to raise_error(Actor::ArgumentError, /Cannot call foobar= on/)
+          .to raise_error(NoMethodError, /undefined method `foobar='/)
       end
     end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -217,6 +217,13 @@ RSpec.describe Actor do
       end
     end
 
+    context 'when reading an output' do
+      it 'succeeds' do
+        result = SetAndAccessOutput.result
+        expect(result.email).to eq('jim@example.org')
+      end
+    end
+
     context 'when disallowing nil on an input' do
       context 'when given the input' do
         it 'succeeds' do

--- a/spec/examples/add_greeting_with_default.rb
+++ b/spec/examples/add_greeting_with_default.rb
@@ -5,6 +5,6 @@ class AddGreetingWithDefault < Actor
   output :greeting, type: 'String'
 
   def call
-    context.greeting = "Hello, #{name}!"
+    self.greeting = "Hello, #{name}!"
   end
 end

--- a/spec/examples/add_greeting_with_lambda_default.rb
+++ b/spec/examples/add_greeting_with_lambda_default.rb
@@ -5,6 +5,6 @@ class AddGreetingWithLambdaDefault < Actor
   output :greeting, type: 'String'
 
   def call
-    context.greeting = "Hello, #{name}!"
+    self.greeting = "Hello, #{name}!"
   end
 end

--- a/spec/examples/add_hash_to_context.rb
+++ b/spec/examples/add_hash_to_context.rb
@@ -4,6 +4,6 @@ class AddHashToContext < Actor
   output :stuff, type: 'Hash'
 
   def call
-    context.stuff = { name: 'Jim' }
+    self.stuff = { name: 'Jim' }
   end
 end

--- a/spec/examples/add_name_to_context.rb
+++ b/spec/examples/add_name_to_context.rb
@@ -4,6 +4,6 @@ class AddNameToContext < Actor
   output :name, type: 'String'
 
   def call
-    context.name = 'Jim'
+    self.name = 'Jim'
   end
 end

--- a/spec/examples/disallow_nil_on_output.rb
+++ b/spec/examples/disallow_nil_on_output.rb
@@ -6,6 +6,6 @@ class DisallowNilOnOutput < Actor
   input :test_without_output, default: false
 
   def call
-    context.name = 'Jim' unless test_without_output
+    self.name = 'Jim' unless test_without_output
   end
 end

--- a/spec/examples/disallow_nil_on_output_with_deprecated_required.rb
+++ b/spec/examples/disallow_nil_on_output_with_deprecated_required.rb
@@ -6,6 +6,6 @@ class DisallowNilOnOutputWithDeprecatedRequired < Actor
   input :test_without_output, default: false
 
   def call
-    context.name = 'Jim' unless test_without_output
+    self.name = 'Jim' unless test_without_output
   end
 end

--- a/spec/examples/increment_value.rb
+++ b/spec/examples/increment_value.rb
@@ -5,6 +5,6 @@ class IncrementValue < Actor
   output :value, type: 'Integer'
 
   def call
-    context.value += 1
+    self.value += 1
   end
 end

--- a/spec/examples/increment_value_with_rollback.rb
+++ b/spec/examples/increment_value_with_rollback.rb
@@ -5,10 +5,10 @@ class IncrementValueWithRollback < Actor
   output :value, type: 'Integer'
 
   def call
-    context.value += 1
+    self.value += 1
   end
 
   def rollback
-    context.value -= 1
+    self.value -= 1
   end
 end

--- a/spec/examples/inherit_from_increment_value.rb
+++ b/spec/examples/inherit_from_increment_value.rb
@@ -6,6 +6,6 @@ class InheritFromIncrementValue < IncrementValue
   def call
     super
 
-    context.value += 1
+    self.value += 1
   end
 end

--- a/spec/examples/set_and_access_output.rb
+++ b/spec/examples/set_and_access_output.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SetAndAccessOutput < Actor
+  output :nickname
+  output :email
+
+  def call
+    self.nickname = 'jim'
+    self.email = "#{nickname}@example.org"
+  end
+end

--- a/spec/examples/set_name_to_downcase.rb
+++ b/spec/examples/set_name_to_downcase.rb
@@ -5,6 +5,6 @@ class SetNameToDowncase < Actor
   output :name, type: 'String'
 
   def call
-    context.name = name.downcase
+    self.name = name.downcase
   end
 end

--- a/spec/examples/set_name_with_input_condition.rb
+++ b/spec/examples/set_name_with_input_condition.rb
@@ -10,6 +10,6 @@ class SetNameWithInputCondition < Actor
   output :name
 
   def call
-    context.name = name.upcase
+    self.name = name.upcase
   end
 end

--- a/spec/examples/set_output_called_display.rb
+++ b/spec/examples/set_output_called_display.rb
@@ -4,6 +4,6 @@ class SetOutputCalledDisplay < Actor
   output :display
 
   def call
-    context.display = 'Foobar'
+    self.display = 'Foobar'
   end
 end

--- a/spec/examples/set_unknown_output.rb
+++ b/spec/examples/set_unknown_output.rb
@@ -4,6 +4,6 @@ class SetUnknownOutput < Actor
   output :name
 
   def call
-    context.foobar = 42
+    self.foobar = 42
   end
 end

--- a/spec/examples/set_wrong_type_of_output.rb
+++ b/spec/examples/set_wrong_type_of_output.rb
@@ -4,6 +4,6 @@ class SetWrongTypeOfOutput < Actor
   output :name, type: 'String'
 
   def call
-    context.name = 42
+    self.name = 42
   end
 end


### PR DESCRIPTION
This helps have a better symetrical use of contexts as methods defined in your actors.

Also adds reader methods to the context so you can use anything you just set on the context right away inside your actor.

(Thanks @annesottise for the feedback leading to this change.)