### PR TITLE
Rename context to result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 Added:
+- Rename `Actor::Context` to `Actor::Result`.
+- Deprecate `context.` in favor of `result.`.
 - Outputs add writer methods inside your actors, so you can do `self.name =`
   instead of `context.name =`.
 - Outputs adds reader methods as well, so you can use anything you just set on

--- a/lib/actor/attributable.rb
+++ b/lib/actor/attributable.rb
@@ -24,7 +24,7 @@ class Actor
         inputs[name] = arguments
 
         define_method(name) do
-          context[name]
+          result[name]
         end
 
         protected name
@@ -38,11 +38,11 @@ class Actor
         outputs[name] = arguments
 
         define_method(name) do
-          context[name]
+          result[name]
         end
 
         define_method("#{name}=") do |value|
-          context[name] = value
+          result[name] = value
         end
 
         protected name, "#{name}="

--- a/lib/actor/conditionable.rb
+++ b/lib/actor/conditionable.rb
@@ -20,7 +20,7 @@ class Actor
         next unless options[:must]
 
         options[:must].each do |name, check|
-          value = context[key]
+          value = result[key]
           next if check.call(value)
 
           raise Actor::ArgumentError,

--- a/lib/actor/defaultable.rb
+++ b/lib/actor/defaultable.rb
@@ -13,7 +13,7 @@ class Actor
   module Defaultable
     def before
       self.class.inputs.each do |name, input|
-        next if context.key?(name)
+        next if result.key?(name)
 
         unless input.key?(:default)
           raise Actor::ArgumentError,
@@ -22,7 +22,7 @@ class Actor
 
         default = input[:default]
         default = default.call if default.respond_to?(:call)
-        context[name] = default
+        result[name] = default
       end
 
       super

--- a/lib/actor/failure.rb
+++ b/lib/actor/failure.rb
@@ -3,14 +3,14 @@
 class Actor
   # Error raised when using `fail!` inside an actor.
   class Failure < Actor::Error
-    def initialize(context)
-      @context = context
+    def initialize(result)
+      @result = result
 
-      error = context.respond_to?(:error) ? context.error : nil
+      error = result.respond_to?(:error) ? result.error : nil
 
       super(error)
     end
 
-    attr_reader :context
+    attr_reader :result
   end
 end

--- a/lib/actor/nil_checkable.rb
+++ b/lib/actor/nil_checkable.rb
@@ -28,7 +28,7 @@ class Actor
       definitions.each do |key, options|
         options = deprecated_required_option(options, name: key, origin: origin)
 
-        next unless context[key].nil?
+        next unless result[key].nil?
         next unless options.key?(:allow_nil)
         next if options[:allow_nil]
 

--- a/lib/actor/playable.rb
+++ b/lib/actor/playable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Actor
-  # DSL to call a series of actors with the same context. On failure, calls
+  # DSL to call a series of actors with the same result. On failure, calls
   # rollback on any actor that succeeded.
   #
   #   class CreateUser < Actor
@@ -38,7 +38,7 @@ class Actor
     module PrependedMethods
       def call
         self.class.play_actors.each do |options|
-          next if options[:if] && !options[:if].call(context)
+          next if options[:if] && !options[:if].call(result)
 
           play_actor(options[:actor])
         end
@@ -61,10 +61,10 @@ class Actor
 
       def play_actor(actor)
         if actor.is_a?(Class) && actor.ancestors.include?(Actor)
-          actor = actor.new(context)
+          actor = actor.new(result)
           actor.run
         else
-          actor.call(context)
+          actor.call(result)
         end
 
         (@played ||= []).unshift(actor)

--- a/lib/actor/result.rb
+++ b/lib/actor/result.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
 class Actor
-  # Represents the result of an action.
-  class Context < OpenStruct
-    def self.to_context(data)
+  # Represents the result of an actor.
+  class Result < OpenStruct
+    def self.to_result(data)
       return data if data.is_a?(self)
 
       new(data.to_h)
     end
 
     def inspect
-      "<ActorContext #{to_h}>"
+      "<#{self.class.name} #{to_h}>"
     end
 
-    def fail!(context = {})
-      merge!(context)
+    def fail!(result = {})
+      merge!(result)
       merge!(failure?: true)
 
       raise Actor::Failure, self
     end
 
-    def succeed!(context = {})
-      merge!(context)
+    def succeed!(result = {})
+      merge!(result)
       merge!(failure?: false)
 
       raise Actor::Success, self
@@ -35,8 +35,8 @@ class Actor
       super || false
     end
 
-    def merge!(context)
-      context.each_pair do |key, value|
+    def merge!(result)
+      result.each_pair do |key, value|
         self[key] = value
       end
 

--- a/lib/actor/type_checkable.rb
+++ b/lib/actor/type_checkable.rb
@@ -29,7 +29,7 @@ class Actor
     def check_type_definitions(definitions, kind:)
       definitions.each do |key, options|
         type_definition = options[:type] || next
-        value = context[key] || next
+        value = result[key] || next
 
         types = Array(type_definition).map { |name| Object.const_get(name) }
         next if types.any? { |type| value.is_a?(type) }

--- a/lib/service_actor.rb
+++ b/lib/service_actor.rb
@@ -8,8 +8,8 @@ require 'actor/failure'
 require 'actor/success'
 require 'actor/argument_error'
 
-# Context
-require 'actor/context'
+# Result
+require 'actor/result'
 
 # Modules
 require 'actor/playable'
@@ -30,15 +30,15 @@ class Actor
   prepend Conditionable
 
   class << self
-    # Call an actor with a given context. Returns the context.
+    # Call an actor with a given result. Returns the result.
     #
     #   CreateUser.call(name: 'Joe')
-    def call(context = {}, **arguments)
-      context = Actor::Context.to_context(context).merge!(arguments)
-      new(context).run
-      context
+    def call(options = nil, **arguments)
+      result = Actor::Result.to_result(options).merge!(arguments)
+      new(result).run
+      result
     rescue Actor::Success
-      context
+      result
     end
 
     # :nodoc:
@@ -47,20 +47,20 @@ class Actor
       call(**arguments)
     end
 
-    # Call an actor with a given context. Returns the context and does not raise
-    # on failure.
+    # Call an actor with arguments. Returns the result and does not raise on
+    # failure.
     #
     #   CreateUser.result(name: 'Joe')
-    def result(context = {}, **arguments)
-      call(context, **arguments)
+    def result(data = nil, **arguments)
+      call(data, **arguments)
     rescue Actor::Failure => e
-      e.context
+      e.result
     end
   end
 
   # :nodoc:
-  def initialize(context)
-    @context = context
+  def initialize(result)
+    @result = result
   end
 
   # To implement in your actors.
@@ -85,15 +85,21 @@ class Actor
   private
 
   # Returns the current context from inside an actor.
-  attr_reader :context
+  attr_reader :result
+
+  def context
+    warn "DEPRECATED: Prefer `result.` to `context.` in #{self.class.name}."
+
+    result
+  end
 
   # Can be called from inside an actor to stop execution and mark as failed.
   def fail!(**arguments)
-    context.fail!(**arguments)
+    result.fail!(**arguments)
   end
 
   # Can be called from inside an actor to stop execution early.
   def succeed!(**arguments)
-    context.succeed!(**arguments)
+    result.succeed!(**arguments)
   end
 end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Actor do
     context 'when fail! is not called' do
       it 'succeeds' do
         result = DoNothing.call
-        expect(result).to be_kind_of(Actor::Context)
+        expect(result).to be_kind_of(Actor::Result)
         expect(result).to be_a_success
         expect(result).not_to be_a_failure
       end
@@ -46,13 +46,13 @@ RSpec.describe Actor do
 
     context 'when given a context instead of a hash' do
       it 'returns the same context' do
-        result = Actor::Context.new(name: 'Jim')
+        result = Actor::Result.new(name: 'Jim')
 
         expect(AddNameToContext.call(result)).to eq(result)
       end
 
       it 'can update the given context' do
-        result = Actor::Context.new(name: 'Jim')
+        result = Actor::Result.new(name: 'Jim')
 
         SetNameToDowncase.call(result)
 
@@ -84,7 +84,7 @@ RSpec.describe Actor do
       end
 
       it 'ignores values already in the context' do
-        result = AddGreetingWithDefault.call(Actor::Context.new(name: 'jim'))
+        result = AddGreetingWithDefault.call(Actor::Result.new(name: 'jim'))
         expect(result.name).to eq('jim')
       end
     end
@@ -150,7 +150,7 @@ RSpec.describe Actor do
 
       it 'changes the context up to the failure and calls rollbacks' do
         data = { value: 0 }
-        result = Actor::Context.new(data)
+        result = Actor::Result.new(data)
 
         expect { FailPlayingActionsWithRollback.call(result) }
           .to raise_error(Actor::Failure)
@@ -327,7 +327,7 @@ RSpec.describe Actor do
     context 'when calling an actor that succeeds early' do
       it 'succeeds' do
         result = SucceedEarly.call
-        expect(result).to be_kind_of(Actor::Context)
+        expect(result).to be_kind_of(Actor::Result)
         expect(result).to be_a_success
         expect(result).not_to be_a_failure
       end
@@ -336,7 +336,7 @@ RSpec.describe Actor do
     context 'when playing an actor that succeeds early' do
       it 'succeeds' do
         result = SucceedPlayingActions.call
-        expect(result).to be_kind_of(Actor::Context)
+        expect(result).to be_kind_of(Actor::Result)
         expect(result).to be_a_success
         expect(result).not_to be_a_failure
         expect(result.count).to eq(1)
@@ -368,7 +368,7 @@ RSpec.describe Actor do
         .to output(expected_warning)
         .to_stderr
 
-      expect(result).to be_kind_of(Actor::Context)
+      expect(result).to be_kind_of(Actor::Result)
       expect(result).to be_a_success
       expect(result).not_to be_a_failure
     end
@@ -378,7 +378,7 @@ RSpec.describe Actor do
     context 'when fail! is not called' do
       it 'succeeds' do
         result = DoNothing.result
-        expect(result).to be_kind_of(Actor::Context)
+        expect(result).to be_kind_of(Actor::Result)
         expect(result).to be_a_success
         expect(result).not_to be_a_failure
       end
@@ -387,7 +387,7 @@ RSpec.describe Actor do
     context 'when fail! is called' do
       it 'fails' do
         result = FailWithError.result
-        expect(result).to be_kind_of(Actor::Context)
+        expect(result).to be_kind_of(Actor::Result)
         expect(result).to be_a_failure
         expect(result).not_to be_a_success
       end
@@ -421,7 +421,7 @@ RSpec.describe Actor do
     context 'when calling an actor that succeeds early' do
       it 'succeeds' do
         result = SucceedEarly.result
-        expect(result).to be_kind_of(Actor::Context)
+        expect(result).to be_kind_of(Actor::Result)
         expect(result).to be_a_success
         expect(result).not_to be_a_failure
       end
@@ -430,7 +430,7 @@ RSpec.describe Actor do
     context 'when playing an actor that succeeds early' do
       it 'succeeds' do
         result = SucceedPlayingActions.result
-        expect(result).to be_kind_of(Actor::Context)
+        expect(result).to be_kind_of(Actor::Result)
         expect(result).to be_a_success
         expect(result).not_to be_a_failure
         expect(result.count).to eq(1)


### PR DESCRIPTION
In order to clarify calls and naming in general, rename `context.` to `result.`.

(Warning added to keep backwards compatibility.)

Thank to [@nicoolas25](https://github.com/nicoolas25/actor/pull/1) for the feedback that both terms (`result` and `context`) were used in the README, not hindering comprehension.