### PR TITLE
Remove before, after and run methods on actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Added:
 - Do not raise an error when accessing `context.` with unknown inputs or
   outputs.
 
+Fixes:
+- Do not expose methods called `before`, `after` and `run` in actors.
+
 ## v1.1.0
 
 Added:

--- a/lib/actor/conditionable.rb
+++ b/lib/actor/conditionable.rb
@@ -13,9 +13,7 @@ class Actor
   #           }
   #   end
   module Conditionable
-    def before
-      super
-
+    def _call
       self.class.inputs.each do |key, options|
         next unless options[:must]
 
@@ -27,6 +25,8 @@ class Actor
                 "Input #{key} must #{name} but was #{value.inspect}."
         end
       end
+
+      super
     end
   end
 end

--- a/lib/actor/defaultable.rb
+++ b/lib/actor/defaultable.rb
@@ -11,7 +11,7 @@ class Actor
   #     input :multiplier, default: -> { rand(1..10) }
   #   end
   module Defaultable
-    def before
+    def _call
       self.class.inputs.each do |name, input|
         next if context.key?(name)
 

--- a/lib/actor/nil_checkable.rb
+++ b/lib/actor/nil_checkable.rb
@@ -10,13 +10,9 @@ class Actor
   #     output :user, allow_nil: false
   #   end
   module NilCheckable
-    def before
-      super
-
+    def _call
       check_context_for_nil(self.class.inputs, origin: 'input')
-    end
 
-    def after
       super
 
       check_context_for_nil(self.class.outputs, origin: 'output')

--- a/lib/actor/playable.rb
+++ b/lib/actor/playable.rb
@@ -62,7 +62,7 @@ class Actor
       def play_actor(actor)
         if actor.is_a?(Class) && actor.ancestors.include?(Actor)
           actor = actor.new(context)
-          actor.run
+          actor._call
         else
           actor.call(context)
         end

--- a/lib/actor/type_checkable.rb
+++ b/lib/actor/type_checkable.rb
@@ -12,13 +12,9 @@ class Actor
   #     input :bonus_applied, type: %w[TrueClass FalseClass]
   #   end
   module TypeCheckable
-    def before
-      super
-
+    def _call
       check_type_definitions(self.class.inputs, kind: 'Input')
-    end
 
-    def after
       super
 
       check_type_definitions(self.class.outputs, kind: 'Output')

--- a/lib/service_actor.rb
+++ b/lib/service_actor.rb
@@ -35,7 +35,7 @@ class Actor
     #   CreateUser.call(name: 'Joe')
     def call(context = {}, **arguments)
       context = Actor::Context.to_context(context).merge!(arguments)
-      new(context).run
+      new(context)._call
       context
     rescue Actor::Success
       context
@@ -70,16 +70,8 @@ class Actor
   def rollback; end
 
   # :nodoc:
-  def before; end
-
-  # :nodoc:
-  def after; end
-
-  # :nodoc:
-  def run
-    before
+  def _call
     call
-    after
   end
 
   private


### PR DESCRIPTION
Allows inputs and outputs called `before`, `after` and `run` thanks to a little refactoring.

Follows feedback from [@nicoolas25](https://github.com/nicoolas25/actor/pull/1) (thanks!).