### PR TITLE
Prefer included modules and use a base module

### DIFF
--- a/lib/actor/base.rb
+++ b/lib/actor/base.rb
@@ -8,7 +8,7 @@ class Actor
   # method.
   module Base
     def self.included(base)
-      base.extend(Actor::ClassMethods)
+      base.extend(ClassMethods)
       base.include(Actor::Attributable)
       base.include(Actor::Playable)
     end

--- a/lib/actor/base.rb
+++ b/lib/actor/base.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'actor/attributable'
+require 'actor/playable'
+
+class Actor
+  # Actors should start with a verb, inherit from Actor and implement a `call`
+  # method.
+  module Base
+    def self.included(base)
+      base.extend(Actor::ClassMethods)
+      base.include(Actor::Attributable)
+      base.include(Actor::Playable)
+    end
+
+    module ClassMethods
+      # Call an actor with a given result. Returns the result.
+      #
+      #   CreateUser.call(name: 'Joe')
+      def call(options = nil, **arguments)
+        result = Actor::Result.to_result(options).merge!(arguments)
+        new(result)._call
+        result
+      rescue Actor::Success
+        result
+      end
+
+      # :nodoc:
+      def call!(**arguments)
+        warn "DEPRECATED: Prefer `#{name}.call` to `#{name}.call!`."
+        call(**arguments)
+      end
+
+      # Call an actor with arguments. Returns the result and does not raise on
+      # failure.
+      #
+      #   CreateUser.result(name: 'Joe')
+      def result(data = nil, **arguments)
+        call(data, **arguments)
+      rescue Actor::Failure => e
+        e.result
+      end
+    end
+
+    # :nodoc:
+    def initialize(result)
+      @result = result
+    end
+
+    # To implement in your actors.
+    def call; end
+
+    # To implement in your actors.
+    def rollback; end
+
+    # :nodoc:
+    def _call
+      call
+    end
+
+    private
+
+    # Returns the current context from inside an actor.
+    attr_reader :result
+
+    def context
+      warn "DEPRECATED: Prefer `result.` to `context.` in #{self.class.name}."
+
+      result
+    end
+
+    # Can be called from inside an actor to stop execution and mark as failed.
+    def fail!(**arguments)
+      result.fail!(**arguments)
+    end
+
+    # Can be called from inside an actor to stop execution early.
+    def succeed!(**arguments)
+      result.succeed!(**arguments)
+    end
+  end
+end

--- a/lib/actor/conditionable.rb
+++ b/lib/actor/conditionable.rb
@@ -13,20 +13,26 @@ class Actor
   #           }
   #   end
   module Conditionable
-    def _call
-      self.class.inputs.each do |key, options|
-        next unless options[:must]
+    def self.included(base)
+      base.prepend(PrependedMethods)
+    end
 
-        options[:must].each do |name, check|
-          value = result[key]
-          next if check.call(value)
+    module PrependedMethods
+      def _call
+        self.class.inputs.each do |key, options|
+          next unless options[:must]
 
-          raise Actor::ArgumentError,
-                "Input #{key} must #{name} but was #{value.inspect}."
+          options[:must].each do |name, check|
+            value = result[key]
+            next if check.call(value)
+
+            raise Actor::ArgumentError,
+                  "Input #{key} must #{name} but was #{value.inspect}."
+          end
         end
-      end
 
-      super
+        super
+      end
     end
   end
 end

--- a/lib/actor/defaultable.rb
+++ b/lib/actor/defaultable.rb
@@ -11,21 +11,27 @@ class Actor
   #     input :multiplier, default: -> { rand(1..10) }
   #   end
   module Defaultable
-    def _call
-      self.class.inputs.each do |name, input|
-        next if result.key?(name)
+    def self.included(base)
+      base.prepend(PrependedMethods)
+    end
 
-        unless input.key?(:default)
-          raise Actor::ArgumentError,
-                "Input #{name} on #{self.class} is missing."
+    module PrependedMethods
+      def _call
+        self.class.inputs.each do |name, input|
+          next if result.key?(name)
+
+          unless input.key?(:default)
+            raise Actor::ArgumentError,
+                  "Input #{name} on #{self.class} is missing."
+          end
+
+          default = input[:default]
+          default = default.call if default.respond_to?(:call)
+          result[name] = default
         end
 
-        default = input[:default]
-        default = default.call if default.respond_to?(:call)
-        result[name] = default
+        super
       end
-
-      super
     end
   end
 end

--- a/lib/actor/playable.rb
+++ b/lib/actor/playable.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Actor
-  # DSL to call a series of actors with the same result. On failure, calls
-  # rollback on any actor that succeeded.
+  # Play class method to call a series of actors with the same result. On
+  # failure, calls rollback on any actor that succeeded.
   #
   #   class CreateUser < Actor
   #     play SaveUser,

--- a/lib/actor/result.rb
+++ b/lib/actor/result.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 class Actor
   # Represents the result of an actor.
   class Result < OpenStruct

--- a/lib/service_actor.rb
+++ b/lib/service_actor.rb
@@ -1,97 +1,25 @@
 # frozen_string_literal: true
 
-require 'ostruct'
-
 # Exceptions
 require 'actor/error'
 require 'actor/failure'
 require 'actor/success'
 require 'actor/argument_error'
 
-# Result
+# Base
+require 'actor/base'
 require 'actor/result'
 
 # Modules
-require 'actor/playable'
-require 'actor/attributable'
 require 'actor/defaultable'
 require 'actor/type_checkable'
 require 'actor/nil_checkable'
 require 'actor/conditionable'
 
-# Actors should start with a verb, inherit from Actor and implement a `call`
-# method.
 class Actor
-  include Attributable
-  include Playable
-  prepend Defaultable
-  prepend TypeCheckable
-  prepend NilCheckable
-  prepend Conditionable
-
-  class << self
-    # Call an actor with a given result. Returns the result.
-    #
-    #   CreateUser.call(name: 'Joe')
-    def call(options = nil, **arguments)
-      result = Actor::Result.to_result(options).merge!(arguments)
-      new(result)._call
-      result
-    rescue Actor::Success
-      result
-    end
-
-    # :nodoc:
-    def call!(**arguments)
-      warn "DEPRECATED: Prefer `#{name}.call` to `#{name}.call!`."
-      call(**arguments)
-    end
-
-    # Call an actor with arguments. Returns the result and does not raise on
-    # failure.
-    #
-    #   CreateUser.result(name: 'Joe')
-    def result(data = nil, **arguments)
-      call(data, **arguments)
-    rescue Actor::Failure => e
-      e.result
-    end
-  end
-
-  # :nodoc:
-  def initialize(result)
-    @result = result
-  end
-
-  # To implement in your actors.
-  def call; end
-
-  # To implement in your actors.
-  def rollback; end
-
-  # :nodoc:
-  def _call
-    call
-  end
-
-  private
-
-  # Returns the current context from inside an actor.
-  attr_reader :result
-
-  def context
-    warn "DEPRECATED: Prefer `result.` to `context.` in #{self.class.name}."
-
-    result
-  end
-
-  # Can be called from inside an actor to stop execution and mark as failed.
-  def fail!(**arguments)
-    result.fail!(**arguments)
-  end
-
-  # Can be called from inside an actor to stop execution early.
-  def succeed!(**arguments)
-    result.succeed!(**arguments)
-  end
+  include Actor::Base
+  include Actor::Defaultable
+  include Actor::TypeCheckable
+  include Actor::NilCheckable
+  include Actor::Conditionable
 end


### PR DESCRIPTION
- [x] Prefer `include` for every module so that the module itself decides whether to `prepend` or not
- [x] Use a `Base` module to make it clearer what is the required core.

Following feedback from [@nicoolas25](https://github.com/nicoolas25/actor/pull/1) (thanks!).