### PR TITLE
Move to service actor namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+Breaking changes:
+- Move all code inside `ServiceActor`, only exposing a base `Actor`, enabling
+  you to change the default class name.
+
 Added:
 - Rename `Actor::Context` to `Actor::Result`.
 - Deprecate `context.` in favor of `result.`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,26 +5,24 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-Breaking changes:
+Added:
 - Move all code inside `ServiceActor`, only exposing a base `Actor`, enabling
   you to change the default class name.
-
-Added:
-- Rename `Actor::Context` to `Actor::Result`.
+- Rename `Actor::Context` to `ServiceActor::Result`.
 - Deprecate `context.` in favor of `result.`.
 - Outputs add writer methods inside your actors, so you can do `self.name =`
-  instead of `context.name =`.
+  instead of `result.name =`.
 - Outputs adds reader methods as well, so you can use anything you just set on
-  the context right away inside your actor.
+  the result right away inside your actor.
 - Deprecate `required: true` in favor of `allow_nil: false`.
-- In case of argument errors, raise an `Actor::ArgumentError` instead of a
-  `ArgumentError`.
-- All errors inherit from `Actor::Error`.
-- Do not raise an error when accessing `context.` with unknown inputs or
-  outputs.
+- All errors inherit from `ServiceActor::Error`.
+- In case of argument errors, raise an `ServiceActor::ArgumentError` instead of
+  a `ArgumentError`.
 
 Fixes:
-- Do not expose methods called `before`, `after` and `run` in actors.
+- Allow inputs and outputs called `before`, `after` and `run`.
+- Do not raise an error when accessing `result.` with unknown inputs or
+  outputs.
 
 ## v1.1.0
 

--- a/README.md
+++ b/README.md
@@ -320,13 +320,14 @@ end
 
 ### Build your own actor
 
-If you application already uses "Actor", you can build your own with:
+If you application already uses an "Actor" class, you can build your own by
+changing the gem's require statement:
 
 ```rb
 gem 'service_actor', require: 'service_actor/base'
 ```
 
-And building your own class:
+And building your own class to inherit from:
 
 ```rb
 class ApplicationActor

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ end
 Trigger them in your application with `.call`:
 
 ```rb
-SendNotification.call # => <Actor::Result…>
+SendNotification.call # => <ServiceActor::Result…>
 ```
 
 When called, actors return a Result. Reading and writing to this result allows
@@ -132,7 +132,7 @@ If an input does not have a default, it will raise a error:
 
 ```rb
 result = BuildGreeting.call
-=> Actor::ArgumentError: Input name on BuildGreeting is missing.
+=> ServiceActor::ArgumentError: Input name on BuildGreeting is missing.
 ```
 
 ### Conditions
@@ -315,6 +315,22 @@ class PlaceOrder < Actor
   play CreateOrder,
        Pay
   play NotifyAdmins, if: ->(ctx) { ctx.order.amount > 42 }
+end
+```
+
+### Build your own actor
+
+If you application already uses "Actor", you can build your own with:
+
+```rb
+gem 'service_actor', require: 'service_actor/base'
+```
+
+And building your own class:
+
+```rb
+class ApplicationActor
+  include ServiceActor::Base
 end
 ```
 

--- a/lib/service_actor.rb
+++ b/lib/service_actor.rb
@@ -1,25 +1,8 @@
 # frozen_string_literal: true
 
-# Exceptions
-require 'actor/error'
-require 'actor/failure'
-require 'actor/success'
-require 'actor/argument_error'
+require 'service_actor/base'
 
-# Base
-require 'actor/base'
-require 'actor/result'
-
-# Modules
-require 'actor/defaultable'
-require 'actor/type_checkable'
-require 'actor/nil_checkable'
-require 'actor/conditionable'
-
+# Class to inherit from in your application.
 class Actor
-  include Actor::Base
-  include Actor::Defaultable
-  include Actor::TypeCheckable
-  include Actor::NilCheckable
-  include Actor::Conditionable
+  include ServiceActor::Base
 end

--- a/lib/service_actor/argument_error.rb
+++ b/lib/service_actor/argument_error.rb
@@ -2,5 +2,5 @@
 
 module ServiceActor
   # Raised when an input or output does not match the given conditions.
-  class ArgumentError < ServiceActor::Error; end
+  class ArgumentError < Error; end
 end

--- a/lib/service_actor/argument_error.rb
+++ b/lib/service_actor/argument_error.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Raised when an input or output does not match the given conditions.
-  class ArgumentError < Actor::Error; end
+  class ArgumentError < ServiceActor::Error; end
 end

--- a/lib/service_actor/attributable.rb
+++ b/lib/service_actor/attributable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # DSL to document the accepted attributes.
   #
   #   class CreateUser < Actor

--- a/lib/service_actor/base.rb
+++ b/lib/service_actor/base.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'service_actor/core'
+
+# Exceptions
+require 'service_actor/error'
+require 'service_actor/failure'
+require 'service_actor/success'
+require 'service_actor/argument_error'
+
+# Core
+require 'service_actor/result'
+require 'service_actor/attributable'
+require 'service_actor/playable'
+require 'service_actor/core'
+
+# Concerns
+require 'service_actor/defaultable'
+require 'service_actor/type_checkable'
+require 'service_actor/nil_checkable'
+require 'service_actor/conditionable'
+
+module ServiceActor
+  module Base
+    def self.included(base)
+      # Core
+      base.include(Core)
+
+      # Concerns
+      base.include(Defaultable)
+      base.include(TypeCheckable)
+      base.include(NilCheckable)
+      base.include(Conditionable)
+    end
+  end
+end

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Add checks to your inputs, by calling lambdas with the name of you choice.
   # Will raise an error if any check does return a truthy value.
   #
@@ -26,7 +26,7 @@ class Actor
             value = result[key]
             next if check.call(value)
 
-            raise Actor::ArgumentError,
+            raise ArgumentError,
                   "Input #{key} must #{name} but was #{value.inspect}."
           end
         end

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
-require 'actor/attributable'
-require 'actor/playable'
-
-class Actor
+module ServiceActor
   # Actors should start with a verb, inherit from Actor and implement a `call`
   # method.
-  module Base
+  module Core
     def self.included(base)
       base.extend(ClassMethods)
-      base.include(Actor::Attributable)
-      base.include(Actor::Playable)
+      base.include(Attributable)
+      base.include(Playable)
     end
 
     module ClassMethods
@@ -18,10 +15,10 @@ class Actor
       #
       #   CreateUser.call(name: 'Joe')
       def call(options = nil, **arguments)
-        result = Actor::Result.to_result(options).merge!(arguments)
+        result = Result.to_result(options).merge!(arguments)
         new(result)._call
         result
-      rescue Actor::Success
+      rescue Success
         result
       end
 
@@ -37,7 +34,7 @@ class Actor
       #   CreateUser.result(name: 'Joe')
       def result(data = nil, **arguments)
         call(data, **arguments)
-      rescue Actor::Failure => e
+      rescue Failure => e
         e.result
       end
     end

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Adds the `default:` option to inputs. Accepts regular values and lambdas.
   # If no default is set and the value has not been given, raises an error.
   #
@@ -21,8 +21,7 @@ class Actor
           next if result.key?(name)
 
           unless input.key?(:default)
-            raise Actor::ArgumentError,
-                  "Input #{name} on #{self.class} is missing."
+            raise ArgumentError, "Input #{name} on #{self.class} is missing."
           end
 
           default = input[:default]

--- a/lib/service_actor/error.rb
+++ b/lib/service_actor/error.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Standard exception from which other inherit.
   class Error < StandardError; end
 end

--- a/lib/service_actor/failure.rb
+++ b/lib/service_actor/failure.rb
@@ -2,7 +2,7 @@
 
 module ServiceActor
   # Error raised when using `fail!` inside an actor.
-  class Failure < ServiceActor::Error
+  class Failure < Error
     def initialize(result)
       @result = result
 

--- a/lib/service_actor/failure.rb
+++ b/lib/service_actor/failure.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Error raised when using `fail!` inside an actor.
-  class Failure < Actor::Error
+  class Failure < ServiceActor::Error
     def initialize(result)
       @result = result
 

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Ensure your inputs and outputs are not nil by adding `allow_nil: false`.
   #
   # Example:
@@ -33,7 +33,7 @@ class Actor
           next unless options.key?(:allow_nil)
           next if options[:allow_nil]
 
-          raise Actor::ArgumentError,
+          raise ArgumentError,
                 "The #{origin} \"#{key}\" on #{self.class} does not allow " \
                 'nil values.'
         end

--- a/lib/service_actor/playable.rb
+++ b/lib/service_actor/playable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Play class method to call a series of actors with the same result. On
   # failure, calls rollback on any actor that succeeded.
   #
@@ -42,7 +42,7 @@ class Actor
 
           play_actor(options[:actor])
         end
-      rescue Actor::Failure
+      rescue Failure
         rollback
         raise
       end

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -2,7 +2,7 @@
 
 require 'ostruct'
 
-class Actor
+module ServiceActor
   # Represents the result of an actor.
   class Result < OpenStruct
     def self.to_result(data)
@@ -19,14 +19,14 @@ class Actor
       merge!(result)
       merge!(failure?: true)
 
-      raise Actor::Failure, self
+      raise Failure, self
     end
 
     def succeed!(result = {})
       merge!(result)
       merge!(failure?: false)
 
-      raise Actor::Success, self
+      raise Success, self
     end
 
     def success?

--- a/lib/service_actor/success.rb
+++ b/lib/service_actor/success.rb
@@ -2,5 +2,5 @@
 
 module ServiceActor
   # Raised when using `succeed!` to halt the progression of an organizer.
-  class Success < ServiceActor::Error; end
+  class Success < Error; end
 end

--- a/lib/service_actor/success.rb
+++ b/lib/service_actor/success.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Raised when using `succeed!` to halt the progression of an organizer.
-  class Success < Actor::Error; end
+  class Success < ServiceActor::Error; end
 end

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   # Adds `type:` checking to inputs and outputs. Accepts strings that should
   # match an ancestor. Also accepts arrays.
   #
@@ -35,7 +35,7 @@ class Actor
           types = Array(type_definition).map { |name| Object.const_get(name) }
           next if types.any? { |type| value.is_a?(type) }
 
-          raise Actor::ArgumentError,
+          raise ArgumentError,
                 "#{kind} #{key} on #{self.class} must be of type " \
                 "#{types.join(', ')} but was #{value.class}"
         end

--- a/lib/service_actor/version.rb
+++ b/lib/service_actor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Actor
+module ServiceActor
   VERSION = '1.1.0'
 end

--- a/service_actor.gemspec
+++ b/service_actor.gemspec
@@ -3,11 +3,11 @@
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-require 'actor/version'
+require 'service_actor/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'service_actor'
-  spec.version = Actor::VERSION
+  spec.version = ServiceActor::VERSION
 
   spec.require_paths = ['lib']
   spec.authors = ['Sunny Ripert']

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Actor do
-  it 'has a version number' do
-    expect(ServiceActor::VERSION).not_to be_nil
-  end
-
   describe '#call' do
     context 'when fail! is not called' do
       let(:result) { DoNothing.call }

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -1,24 +1,23 @@
 # frozen_string_literal: true
 
-Dir['./spec/examples/*'].sort.each { |f| require f }
-
 RSpec.describe Actor do
   it 'has a version number' do
-    expect(Actor::VERSION).not_to be_nil
+    expect(ServiceActor::VERSION).not_to be_nil
   end
 
   describe '#call' do
     context 'when fail! is not called' do
       let(:result) { DoNothing.call }
 
-      it { expect(result).to be_kind_of(Actor::Result) }
+      it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
     end
 
     context 'when fail! is called' do
       it 'raises the error message' do
-        expect { FailWithError.call }.to raise_error(Actor::Failure, 'Ouch')
+        expect { FailWithError.call }
+          .to raise_error(ServiceActor::Failure, 'Ouch')
       end
     end
 
@@ -45,13 +44,13 @@ RSpec.describe Actor do
 
     context 'when given a context instead of a hash' do
       it 'returns the same context' do
-        result = Actor::Result.new(name: 'Jim')
+        result = ServiceActor::Result.new(name: 'Jim')
 
         expect(AddNameToContext.call(result)).to eq(result)
       end
 
       it 'can update the given context' do
-        result = Actor::Result.new(name: 'Jim')
+        result = ServiceActor::Result.new(name: 'Jim')
 
         SetNameToDowncase.call(result)
 
@@ -83,7 +82,9 @@ RSpec.describe Actor do
       end
 
       it 'ignores values already in the context' do
-        result = AddGreetingWithDefault.call(Actor::Result.new(name: 'jim'))
+        result = AddGreetingWithDefault.call(
+          ServiceActor::Result.new(name: 'jim'),
+        )
         expect(result.name).to eq('jim')
       end
     end
@@ -104,7 +105,7 @@ RSpec.describe Actor do
       it 'raises an error' do
         expect { SetNameToDowncase.call }
           .to raise_error(
-            Actor::ArgumentError,
+            ServiceActor::ArgumentError,
             'Input name on SetNameToDowncase is missing.',
           )
       end
@@ -155,17 +156,17 @@ RSpec.describe Actor do
     end
 
     context 'when playing several actors and one fails' do
-      let(:result) { Actor::Result.new(value: 0) }
+      let(:result) { ServiceActor::Result.new(value: 0) }
 
       it 'raises with the message' do
         expect { FailPlayingActionsWithRollback.call(result) }
-          .to raise_error(Actor::Failure, 'Ouch')
+          .to raise_error(ServiceActor::Failure, 'Ouch')
       end
 
       # rubocop:disable RSpec/MultipleExpectations
       it 'changes the context up to the failure then calls rollbacks' do
         expect { FailPlayingActionsWithRollback.call(result) }
-          .to raise_error(Actor::Failure)
+          .to raise_error(ServiceActor::Failure)
 
         expect(result.name).to eq('Jim')
         expect(result.value).to eq(0)
@@ -184,7 +185,7 @@ RSpec.describe Actor do
         expected_error = 'Input name must be_lowercase but was "42".'
 
         expect { SetNameWithInputCondition.call(name: '42') }
-          .to raise_error(Actor::ArgumentError, expected_error)
+          .to raise_error(ServiceActor::ArgumentError, expected_error)
       end
     end
 
@@ -196,7 +197,7 @@ RSpec.describe Actor do
 
       it 'raises' do
         expect { SetNameToDowncase.call(name: 1) }
-          .to raise_error(Actor::ArgumentError, expected_message)
+          .to raise_error(ServiceActor::ArgumentError, expected_message)
       end
     end
 
@@ -208,7 +209,7 @@ RSpec.describe Actor do
 
       it 'raises' do
         expect { SetWrongTypeOfOutput.call }
-          .to raise_error(Actor::ArgumentError, expected_message)
+          .to raise_error(ServiceActor::ArgumentError, expected_message)
       end
     end
 
@@ -245,7 +246,7 @@ RSpec.describe Actor do
             'The input "name" on DisallowNilOnInput does not allow nil values.'
 
           expect { DisallowNilOnInput.call(name: nil) }
-            .to raise_error(Actor::ArgumentError, expected_error)
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
         end
       end
     end
@@ -280,7 +281,7 @@ RSpec.describe Actor do
 
         it 'fails' do
           expect { DisallowNilOnInputWithDeprecatedRequired.call(name: nil) }
-            .to raise_error(Actor::ArgumentError, expected_error)
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
             .and output(expected_warning).to_stderr
         end
       end
@@ -300,7 +301,7 @@ RSpec.describe Actor do
             'values.'
 
           expect { DisallowNilOnOutput.call(test_without_output: true) }
-            .to raise_error(Actor::ArgumentError, expected_error)
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
         end
       end
     end
@@ -341,7 +342,7 @@ RSpec.describe Actor do
 
         it 'fails' do
           expect { muffled_result }
-            .to raise_error(Actor::ArgumentError, expected_error)
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
         end
       end
     end
@@ -349,7 +350,7 @@ RSpec.describe Actor do
     context 'when calling an actor that succeeds early' do
       let(:result) { SucceedEarly.call }
 
-      it { expect(result).to be_kind_of(Actor::Result) }
+      it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
     end
@@ -357,7 +358,7 @@ RSpec.describe Actor do
     context 'when playing an actor that succeeds early' do
       let(:result) { SucceedPlayingActions.call }
 
-      it { expect(result).to be_kind_of(Actor::Result) }
+      it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
       it { expect(result.count).to eq(1) }
@@ -389,7 +390,7 @@ RSpec.describe Actor do
       result
     end
 
-    it { expect(muffled_result).to be_kind_of(Actor::Result) }
+    it { expect(muffled_result).to be_kind_of(ServiceActor::Result) }
     it { expect(muffled_result).to be_a_success }
     it { expect(muffled_result).not_to be_a_failure }
   end
@@ -398,7 +399,7 @@ RSpec.describe Actor do
     context 'when fail! is not called' do
       let(:result) { DoNothing.result }
 
-      it { expect(result).to be_kind_of(Actor::Result) }
+      it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
     end
@@ -406,7 +407,7 @@ RSpec.describe Actor do
     context 'when fail! is called' do
       let(:result) { FailWithError.result }
 
-      it { expect(result).to be_kind_of(Actor::Result) }
+      it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_failure }
       it { expect(result).not_to be_a_success }
       it { expect(result.error).to eq('Ouch') }
@@ -433,7 +434,7 @@ RSpec.describe Actor do
     context 'when calling an actor that succeeds early' do
       let(:result) { SucceedEarly.result }
 
-      it { expect(result).to be_kind_of(Actor::Result) }
+      it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
     end
@@ -441,7 +442,7 @@ RSpec.describe Actor do
     context 'when playing an actor that succeeds early' do
       let(:result) { SucceedPlayingActions.result }
 
-      it { expect(result).to be_kind_of(Actor::Result) }
+      it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
       it { expect(result.count).to eq(1) }

--- a/spec/examples/inherit_from_custom_base.rb
+++ b/spec/examples/inherit_from_custom_base.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ExampleApplicationActor
+  include ServiceActor::Base
+end
+
+class InheritFromCustomBase < ExampleApplicationActor
+  input :value, type: 'Integer'
+  output :value, type: 'Integer'
+
+  def call
+    self.value += 1
+  end
+end

--- a/spec/service_actor_spec.rb
+++ b/spec/service_actor_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe ServiceActor do
+  describe 'VERSION' do
+    it { expect(ServiceActor::VERSION).not_to be_nil }
+  end
+
+  describe 'Base' do
+    it 'can be used to build your own actor' do
+      result = InheritFromCustomBase.call(value: 41)
+
+      expect(result.value).to eq(42)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'bundler/setup'
 require 'service_actor'
 require 'pry'
 
+Dir['./spec/examples/*'].sort.each { |f| require f }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe Actor do
+  it 'has a version number' do
+    expect(ServiceActor::VERSION).not_to be_nil
+  end
+end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe Actor do
-  it 'has a version number' do
-    expect(ServiceActor::VERSION).not_to be_nil
-  end
-end


### PR DESCRIPTION
This adds a way to choose the base class to inherit from, if `Actor` is already taken.

Thanks @bobmaerten for the [feedback](https://twitter.com/bobmaerten/status/1240998437065232384)!