### PR TITLE
Deprecate early success in favor of play conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Added:
 - In case of argument errors, raise an `ServiceActor::ArgumentError` instead of
   a `ArgumentError`.
 - Allow classes as well as strings in type definitions.
+- Deprecate early success in favor of play conditions.
 
 Fixes:
 - Allow inputs and outputs called `before`, `after` and `run`.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ and controllers thin.
   - [Result](#result)
 - [Play actors in a sequence](#play-actors-in-a-sequence)
   - [Rollback](#rollback)
-  - [Early success](#early-success)
   - [Lambdas](#lambdas)
   - [Play conditions](#play-conditions)
+- [Build your own actor](#build-your-own-actor)
 - [Testing](#testing)
 - [Influences](#influences)
 - [Development](#development)
@@ -273,11 +273,6 @@ Rollback is only called on the _previous_ actors in `play` and is not called on
 the failing actor itself. Actors should be kept to a single purpose and not have
 anything to clean up if they call `fail!`.
 
-### Early success
-
-When using `play` you can use `succeed!` to stop the execution of the following
-actors, but still consider the actor to be successful.
-
 ### Lambdas
 
 You can use inline actions using lambdas. Inside these lambdas, you don't have
@@ -320,7 +315,9 @@ class PlaceOrder < Actor
 end
 ```
 
-### Build your own actor
+You can use this to trigger an early success.
+
+## Build your own actor
 
 If you application already uses an "Actor" class, you can build your own by
 changing the gem's require statement:
@@ -363,7 +360,7 @@ However there are a few key differences which make `actor` unique:
 - Shorter setup syntax: inherit from `< Actor` vs having to `include Interactor`
   and `include Interactor::Organizer`.
 - Organizers allow lambdas, being called multiple times, and having conditions.
-- Allows triggering an early success with `succeed!`.
+- Allows early success with conditions inside organizers.
 - No `before`, `after` and `around` hooks, prefer using `play` with lambdas or
   overriding `call`.
 

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -18,6 +18,7 @@ module ServiceActor
         result = Result.to_result(options).merge!(arguments)
         new(result)._call
         result
+      # DEPRECATED
       rescue Success
         result
       end
@@ -71,7 +72,7 @@ module ServiceActor
       result.fail!(**arguments)
     end
 
-    # Can be called from inside an actor to stop execution early.
+    # DEPRECATED
     def succeed!(**arguments)
       result.succeed!(**arguments)
     end

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -23,6 +23,9 @@ module ServiceActor
     end
 
     def succeed!(result = {})
+      warn 'DEPRECATED: Early success with `succeed!` is deprecated in favor ' \
+           'of adding conditions to `play` calls.'
+
       merge!(result)
       merge!(failure?: false)
 

--- a/lib/service_actor/success.rb
+++ b/lib/service_actor/success.rb
@@ -2,5 +2,6 @@
 
 module ServiceActor
   # Raised when using `succeed!` to halt the progression of an organizer.
+  # DEPRECATED in favor of adding conditions to your play.
   class Success < Error; end
 end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -358,16 +358,42 @@ RSpec.describe Actor do
       end
     end
 
-    context 'when calling an actor that succeeds early' do
-      let(:result) { SucceedEarly.call }
+    context 'when calling an actor with a deprecated early success' do
+      let(:deprecation_message) do
+        'DEPRECATED: Early success with `succeed!` is deprecated in favor of ' \
+        "adding conditions to `play` calls.\n"
+      end
+
+      let(:result) do
+        result = nil
+
+        expect { result = SucceedPlayingActions.call }
+          .to output(deprecation_message)
+          .to_stderr
+
+        result
+      end
 
       it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
     end
 
-    context 'when playing an actor that succeeds early' do
-      let(:result) { SucceedPlayingActions.call }
+    context 'when playing an actor with a deprecated early success' do
+      let(:deprecation_message) do
+        'DEPRECATED: Early success with `succeed!` is deprecated in favor of ' \
+        "adding conditions to `play` calls.\n"
+      end
+
+      let(:result) do
+        result = nil
+
+        expect { result = SucceedPlayingActions.call }
+          .to output(deprecation_message)
+          .to_stderr
+
+        result
+      end
 
       it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
@@ -442,16 +468,42 @@ RSpec.describe Actor do
       it { expect(result.value).to eq(0) }
     end
 
-    context 'when calling an actor that succeeds early' do
-      let(:result) { SucceedEarly.result }
+    context 'when calling an actor with a deprecated early success' do
+      let(:deprecation_message) do
+        'DEPRECATED: Early success with `succeed!` is deprecated in favor of ' \
+        "adding conditions to `play` calls.\n"
+      end
+
+      let(:result) do
+        result = nil
+
+        expect { result = SucceedPlayingActions.result }
+          .to output(deprecation_message)
+          .to_stderr
+
+        result
+      end
 
       it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }
       it { expect(result).not_to be_a_failure }
     end
 
-    context 'when playing an actor that succeeds early' do
-      let(:result) { SucceedPlayingActions.result }
+    context 'when playing an actor with a deprecated early success' do
+      let(:deprecation_message) do
+        'DEPRECATED: Early success with `succeed!` is deprecated in favor of ' \
+        "adding conditions to `play` calls.\n"
+      end
+
+      let(:result) do
+        result = nil
+
+        expect { result = SucceedPlayingActions.result }
+          .to output(deprecation_message)
+          .to_stderr
+
+        result
+      end
 
       it { expect(result).to be_kind_of(ServiceActor::Result) }
       it { expect(result).to be_a_success }

--- a/spec/examples/succeed_early.rb
+++ b/spec/examples/succeed_early.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# DEPRECATED
 class SucceedEarly < Actor
   def call
     succeed!

--- a/spec/examples/succeed_playing_actions.rb
+++ b/spec/examples/succeed_playing_actions.rb
@@ -2,6 +2,7 @@
 
 require_relative './succeed_early'
 
+# DEPRECATED
 class SucceedPlayingActions < Actor
   play ->(ctx) { ctx.count = 1 },
        SucceedEarly,


### PR DESCRIPTION
Simplify the API by deprecating the early success call.

Following [feedback from @nicoolas25](https://github.com/sunny/actor/commit/b76440337760a26f20a0cf58192be1175ca06008#diff-741bba439795449867e5e8162e892da5R12) (thanks!).