### PR TITLE
Disallow nil when a type is set by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+Breaking changes:
+- Disallow nil when a type is set by default.
+
 Added:
 - Move all code inside `ServiceActor`, only exposing a base `Actor`, enabling
   you to change the default class name.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ and controllers thin.
   - [Inputs](#inputs)
   - [Outputs](#outputs)
   - [Defaults](#defaults)
-  - [Types](#types)
-  - [Allow nil](#allow-nil)
   - [Conditions](#conditions)
+  - [Allow nil](#allow-nil)
+  - [Types](#types)
   - [Result](#result)
 - [Play actors in a sequence](#play-actors-in-a-sequence)
   - [Rollback](#rollback)
@@ -153,11 +153,26 @@ end
 
 In case the input does not match, it will raise an argument error.
 
+### Allow nil
+
+By default inputs accept `nil` values. To raise an error instead:
+
+```rb
+class UpdateUser < Actor
+  input :user, allow_nil: false
+
+  # …
+end
+```
+
 ### Types
 
 Sometimes it can help to have a quick way of making sure we didn't mess up our
-inputs. For that you can use `type` with a class or an array of possible classes
-it must be an instance of.
+inputs.
+
+For that you can use the `type` option and giving a class or an array
+of possible classes. If the input or output doesn't match is not an instance of
+these types, an error is raised.
 
 ```rb
 class UpdateUser < Actor
@@ -170,19 +185,7 @@ end
 
 You may also use strings instead of constants, such as `type: 'User'`.
 
-An exception will be raised if the type doesn't match when called.
-
-### Allow nil
-
-By default inputs accept `nil` values. To raise an error instead:
-
-```rb
-class UpdateUser < Actor
-  input :user, allow_nil: false
-
-  # …
-end
-```
+When using a type condition, `allow_nil` defaults to `false`.
 
 ### Result
 

--- a/lib/service_actor/base.rb
+++ b/lib/service_actor/base.rb
@@ -15,10 +15,10 @@ require 'service_actor/playable'
 require 'service_actor/core'
 
 # Concerns
-require 'service_actor/defaultable'
 require 'service_actor/type_checkable'
 require 'service_actor/nil_checkable'
 require 'service_actor/conditionable'
+require 'service_actor/defaultable'
 
 module ServiceActor
   module Base
@@ -27,10 +27,10 @@ module ServiceActor
       base.include(Core)
 
       # Concerns
-      base.include(Defaultable)
       base.include(TypeCheckable)
       base.include(NilCheckable)
       base.include(Conditionable)
+      base.include(Defaultable)
     end
   end
 end

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -28,9 +28,9 @@ module ServiceActor
       def check_context_for_nil(definitions, origin:)
         definitions.each do |key, options|
           options = deprecated_required_option(options, key, origin)
+          options = default_allow_nil(options)
 
           next unless result[key].nil?
-          next unless options.key?(:allow_nil)
           next if options[:allow_nil]
 
           raise ArgumentError,
@@ -48,6 +48,12 @@ module ServiceActor
             "#{self.class}."
 
         options.merge(allow_nil: !options[:required])
+      end
+
+      def default_allow_nil(options)
+        return options if options.key?(:allow_nil)
+
+        options.merge(allow_nil: !options[:type])
       end
     end
   end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -197,6 +197,17 @@ RSpec.describe Actor do
       end
     end
 
+    context 'when a type is defined but the argument is nil' do
+      let(:expected_message) do
+        'The input "name" on SetNameToDowncase does not allow nil values.'
+      end
+
+      it 'raises' do
+        expect { SetNameToDowncase.call(name: nil) }
+          .to raise_error(ServiceActor::ArgumentError, expected_message)
+      end
+    end
+
     context 'when called with a type as a string instead of a class' do
       it 'succeeds' do
         result = DoubleWithTypeAsString.call(value: 2.0)


### PR DESCRIPTION
This is because when you define a type your intention is usually to limit to one type and *not* to allow `nil`.

This follows feedback from @annesottise (thanks!).