### PR TITLE
Add fail_on handler to turn errors into actor failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+Added:
+- Add `fail_on` to catch argument errors and turn them into actor failures.
+
 ## v3.0.0
 
 Added:

--- a/README.md
+++ b/README.md
@@ -337,6 +337,20 @@ end
 
 You can use this to trigger an early success.
 
+### Fail on argument error
+
+By default, errors on inputs will raise an error, even when using `.result`
+instead of `.call`. If instead you want to mark the actor as failed, you can
+catch the exception to treat it as an actor failure:
+
+```rb
+class PlaceOrder < Actor
+  fail_on ServiceActor::ArgumentError
+
+  # …
+end
+```
+
 ## Use with Rails
 
 The [service_actor-rails](https://github.com/sunny/actor-rails/) gem includes a

--- a/lib/service_actor/base.rb
+++ b/lib/service_actor/base.rb
@@ -19,6 +19,7 @@ require 'service_actor/nil_checkable'
 require 'service_actor/conditionable'
 require 'service_actor/defaultable'
 require 'service_actor/collectionable'
+require 'service_actor/failable'
 
 module ServiceActor
   module Base
@@ -34,6 +35,7 @@ module ServiceActor
       base.include(Conditionable)
       base.include(Defaultable)
       base.include(Collectionable)
+      base.include(Failable)
     end
   end
 end

--- a/lib/service_actor/failable.rb
+++ b/lib/service_actor/failable.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ServiceActor
+  # Adds the `fail_on` DSL to actors. This allows you to call `.result` and get
+  # back a failed actor instead of raising an exception.
+  #
+  #   class ApplicationActor < Actor
+  #     fail_on ServiceActor::ArgumentError
+  #   end
+  module Failable
+    def self.included(base)
+      base.extend(ClassMethods)
+      base.prepend(PrependedMethods)
+    end
+
+    module ClassMethods
+      def inherited(child)
+        super
+
+        child.fail_ons.append(*fail_ons)
+      end
+
+      def fail_on(*exceptions)
+        fail_ons.append(*exceptions)
+      end
+
+      def fail_ons
+        @fail_ons ||= []
+      end
+    end
+
+    module PrependedMethods
+      def _call
+        super
+      rescue *self.class.fail_ons => e
+        fail!(error: e.message)
+      end
+    end
+  end
+end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -393,6 +393,17 @@ RSpec.describe Actor do
       it { expect(result.some_other_key).to eq(42) }
     end
 
+    context 'with an argument error, caught by fail_on' do
+      let(:result) { FailOnArgumentError.result(name: 42) }
+      let(:expected_error_message) do
+        'Input name on FailOnArgumentError must be of type String but was ' \
+        'Integer'
+      end
+
+      it { expect(result).to be_a_failure }
+      it { expect(result.error).to eq(expected_error_message) }
+    end
+
     context 'when playing several actors' do
       let(:result) { PlayActors.result(value: 1) }
 

--- a/spec/examples/fail_on_argument_error.rb
+++ b/spec/examples/fail_on_argument_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class FailOnArgumentError < Actor
+  fail_on ServiceActor::ArgumentError
+
+  input :name, type: String, allow_nil: false
+
+  def call; end
+end


### PR DESCRIPTION
This adds the `fail_on` DSL to actors. It allows you to call `.result` and get back a failed actor instead of raising an exception.

For example, for argument errors:

```rb
class PlaceOrder < Actor
  fail_on ServiceActor::ArgumentError

  input :price
end
```

When called with `.result` and incorrect arguments, the error is returned as an actor failure:

```rb
result = PlaceOrder.result # => does not raise even though we didn't provide a price
result.failure? # => true
result.error # => "Input name on FailOnArgumentError is missing"
```

CC @annesottise