### PR TITLE
Do not merge hashes returned by lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Fixes:
 - The `play` method reckognizes as actors anything that inherits from
   `ServiceActor::Core` instead of just `Actor`.
+- The `play` method does not try to merge results of lambdas returning hashes.
 - Remove warning when calling `#rollback`.
 
 ## v3.1.2

--- a/lib/service_actor/playable.rb
+++ b/lib/service_actor/playable.rb
@@ -62,7 +62,7 @@ module ServiceActor
       def play_actor(actor)
         play_service_actor(actor) ||
           play_interactor(actor) ||
-          play_callable_actor(actor)
+          actor.call(result)
       end
 
       def play_service_actor(actor)
@@ -80,10 +80,6 @@ module ServiceActor
         return unless actor.ancestors.map(&:name).include?('Interactor')
 
         result.merge!(actor.call(result).to_h)
-      end
-
-      def play_callable_actor(actor)
-        actor.call(result)
       end
     end
   end

--- a/spec/examples/play_lambdas.rb
+++ b/spec/examples/play_lambdas.rb
@@ -9,5 +9,6 @@ class PlayLambdas < Actor
   play ->(result) { result.value = 3 },
        IncrementValue,
        ->(result) { result.name = "Jim number #{result.value}" },
+       ->(_) { { name: 'Does nothing' } },
        SetNameToDowncase
 end


### PR DESCRIPTION
When a lambda returns a hash, the result of that hash was added to the inputs of the next actor. This could cause inputs to be unintentionally overriden.

```rb
class DoSomething < Actor
  play DoSomethingBefore,
       -> actor { actor.something.a_method_returning_a_hash },
       DoSomethingNext # <- received input from keys in the hash
end
```
  