### PR TITLE
Allow actors as defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## unreleased
 
+Features:
+- Allow using actors as defaults, which can help with dependency injection.
+
 ## v3.2.0
 
 Features:

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -22,7 +22,7 @@ module ServiceActor
 
           if input.key?(:default)
             default = input[:default]
-            default = default.call if default.respond_to?(:call)
+            default = default.call if default.is_a?(Proc)
             result[name] = default
             next
           end


### PR DESCRIPTION
Closes #70

Before this change you would need to write `default: -> { AnotherActor }` instead of `default: -> AnotherActor` if you wanted to use an actor class as a default, for example for dependency injection.