### PR TITLE
Autoloading with Zeitwerk gem ⌚︎

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,9 @@ RSpec/MultipleExpectations:
 Style/AsciiComments:
   Enabled: false
 
+Style/ClassAndModuleChildren:
+  Enabled: false
+
 Style/HashEachMethods:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,7 +51,7 @@ Style/AsciiComments:
   Enabled: false
 
 Style/ClassAndModuleChildren:
-  Enabled: false
+  EnforcedStyle: compact
 
 Style/HashEachMethods:
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     service_actor (3.3.0)
+      zeitwerk
 
 GEM
   remote: https://rubygems.org/
@@ -61,6 +62,7 @@ GEM
       rubocop (= 1.12.1)
     ruby-progressbar (1.11.0)
     unicode-display_width (2.2.0)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby

--- a/lib/service_actor/argument_error.rb
+++ b/lib/service_actor/argument_error.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Raised when an input or output does not match the given conditions.
-  class ArgumentError < Error; end
-end
+# Raised when an input or output does not match the given conditions.
+class ServiceActor::ArgumentError < ServiceActor::Error; end

--- a/lib/service_actor/base.rb
+++ b/lib/service_actor/base.rb
@@ -1,28 +1,20 @@
 # frozen_string_literal: true
 
-require "zeitwerk"
-loader = Zeitwerk::Loader.new
-loader.tag = "service_actor"
-loader.inflector =
-  Zeitwerk::GemInflector.new(File.expand_path("../service_actor.rb", __dir__))
-loader.push_dir(File.expand_path("..", __dir__))
-loader.setup
+require "service_actor/support/loader"
 
-module ServiceActor
-  module Base
-    def self.included(base)
-      # Essential mechanics
-      base.include(Core)
-      base.include(Attributable)
-      base.include(Playable)
+module ServiceActor::Base
+  def self.included(base)
+    # Essential mechanics
+    base.include(ServiceActor::Core)
+    base.include(ServiceActor::Attributable)
+    base.include(ServiceActor::Playable)
 
-      # Extra concerns
-      base.include(TypeCheckable)
-      base.include(NilCheckable)
-      base.include(Conditionable)
-      base.include(Collectionable)
-      base.include(Defaultable)
-      base.include(Failable)
-    end
+    # Extra concerns
+    base.include(ServiceActor::TypeCheckable)
+    base.include(ServiceActor::NilCheckable)
+    base.include(ServiceActor::Conditionable)
+    base.include(ServiceActor::Collectionable)
+    base.include(ServiceActor::Defaultable)
+    base.include(ServiceActor::Failable)
   end
 end

--- a/lib/service_actor/base.rb
+++ b/lib/service_actor/base.rb
@@ -1,33 +1,22 @@
 # frozen_string_literal: true
 
-# Exceptions
-require "service_actor/error"
-require "service_actor/failure"
-require "service_actor/argument_error"
-
-# Core
-require "service_actor/core"
-require "service_actor/attributable"
-require "service_actor/playable"
-require "service_actor/result"
-
-# Concerns
-require "service_actor/type_checkable"
-require "service_actor/nil_checkable"
-require "service_actor/conditionable"
-require "service_actor/defaultable"
-require "service_actor/collectionable"
-require "service_actor/failable"
+require "zeitwerk"
+loader = Zeitwerk::Loader.new
+loader.tag = "service_actor"
+loader.inflector =
+  Zeitwerk::GemInflector.new(File.expand_path("../service_actor.rb", __dir__))
+loader.push_dir(File.expand_path("..", __dir__))
+loader.setup
 
 module ServiceActor
   module Base
     def self.included(base)
-      # Core
+      # Essential mechanics
       base.include(Core)
       base.include(Attributable)
       base.include(Playable)
 
-      # Concerns
+      # Extra concerns
       base.include(TypeCheckable)
       base.include(NilCheckable)
       base.include(Conditionable)

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -1,33 +1,31 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Add checks to your inputs, by specifying what values are authorized
-  # under the "in" key.
-  #
-  # Example:
-  #
-  #   class Pay < Actor
-  #     input :provider, in: ["MANGOPAY", "PayPal", "Stripe"]
-  #   end
-  module Collectionable
-    def self.included(base)
-      base.prepend(PrependedMethods)
-    end
+# Add checks to your inputs, by specifying what values are authorized under the
+# "in" key.
+#
+# Example:
+#
+#   class Pay < Actor
+#     input :provider, in: ["MANGOPAY", "PayPal", "Stripe"]
+#   end
+module ServiceActor::Collectionable
+  def self.included(base)
+    base.prepend(PrependedMethods)
+  end
 
-    module PrependedMethods
-      def _call
-        self.class.inputs.each do |key, options|
-          next unless options[:in]
+  module PrependedMethods
+    def _call
+      self.class.inputs.each do |key, options|
+        next unless options[:in]
 
-          next if options[:in].include?(result[key])
+        next if options[:in].include?(result[key])
 
-          raise ArgumentError,
-                "Input #{key} must be included in #{options[:in].inspect} " \
-                "but instead was #{result[key].inspect}"
-        end
-
-        super
+        raise ArgumentError,
+              "Input #{key} must be included in #{options[:in].inspect} " \
+              "but instead was #{result[key].inspect}"
       end
+
+      super
     end
   end
 end

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -1,40 +1,38 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Add checks to your inputs, by calling lambdas with the name of you choice
-  # under the "must" key.
-  #
-  # Will raise an error if any check returns a truthy value.
-  #
-  # Example:
-  #
-  #   class Pay < Actor
-  #     input :provider,
-  #           must: {
-  #             exist: -> provider { PROVIDERS.include?(provider) },
-  #           }
-  #   end
-  module Conditionable
-    def self.included(base)
-      base.prepend(PrependedMethods)
-    end
+# Add checks to your inputs, by calling lambdas with the name of you choice
+# under the "must" key.
+#
+# Will raise an error if any check returns a truthy value.
+#
+# Example:
+#
+#   class Pay < Actor
+#     input :provider,
+#           must: {
+#             exist: -> provider { PROVIDERS.include?(provider) },
+#           }
+#   end
+module ServiceActor::Conditionable
+  def self.included(base)
+    base.prepend(PrependedMethods)
+  end
 
-    module PrependedMethods
-      def _call
-        self.class.inputs.each do |key, options|
-          next unless options[:must]
+  module PrependedMethods
+    def _call
+      self.class.inputs.each do |key, options|
+        next unless options[:must]
 
-          options[:must].each do |name, check|
-            value = result[key]
-            next if check.call(value)
+        options[:must].each do |name, check|
+          value = result[key]
+          next if check.call(value)
 
-            raise ArgumentError,
-                  "Input #{key} must #{name} but was #{value.inspect}"
-          end
+          raise ServiceActor::ArgumentError,
+                "Input #{key} must #{name} but was #{value.inspect}"
         end
-
-        super
       end
+
+      super
     end
   end
 end

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -1,59 +1,57 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  module Core
-    def self.included(base)
-      base.extend(ClassMethods)
+module ServiceActor::Core
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    # Call an actor with a given result. Returns the result.
+    #
+    #   CreateUser.call(name: "Joe")
+    def call(result = nil, **arguments)
+      result = ServiceActor::Result.to_result(result).merge!(arguments)
+      new(result)._call
+      result
     end
 
-    module ClassMethods
-      # Call an actor with a given result. Returns the result.
-      #
-      #   CreateUser.call(name: "Joe")
-      def call(result = nil, **arguments)
-        result = Result.to_result(result).merge!(arguments)
-        new(result)._call
-        result
-      end
-
-      # Call an actor with arguments. Returns the result and does not raise on
-      # failure.
-      #
-      #   CreateUser.result(name: "Joe")
-      def result(result = nil, **arguments)
-        call(result, **arguments)
-      rescue Failure => e
-        e.result
-      end
+    # Call an actor with arguments. Returns the result and does not raise on
+    # failure.
+    #
+    #   CreateUser.result(name: "Joe")
+    def result(result = nil, **arguments)
+      call(result, **arguments)
+    rescue ServiceActor::Failure => e
+      e.result
     end
+  end
 
-    # :nodoc:
-    def initialize(result)
-      @result = result
-    end
+  # :nodoc:
+  def initialize(result)
+    @result = result
+  end
 
-    # To implement in your actors.
-    def call; end
+  # To implement in your actors.
+  def call; end
 
-    # To implement in your actors.
-    def rollback; end
+  # To implement in your actors.
+  def rollback; end
 
-    # This method is used internally to override behavior on call. Overriding
-    # `call` instead would mean that end-users have to call `super` in their
-    # actors.
-    # :nodoc:
-    def _call
-      call
-    end
+  # This method is used internally to override behavior on call. Overriding
+  # `call` instead would mean that end-users have to call `super` in their
+  # actors.
+  # :nodoc:
+  def _call
+    call
+  end
 
-    protected
+  protected
 
-    # Returns the current context from inside an actor.
-    attr_reader :result
+  # Returns the current context from inside an actor.
+  attr_reader :result
 
-    # Can be called from inside an actor to stop execution and mark as failed.
-    def fail!(**arguments)
-      result.fail!(**arguments)
-    end
+  # Can be called from inside an actor to stop execution and mark as failed.
+  def fail!(**arguments)
+    result.fail!(**arguments)
   end
 end

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -1,37 +1,36 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Adds the `default:` option to inputs. Accepts regular values and lambdas.
-  # If no default is set and the value has not been given, raises an error.
-  #
-  # Example:
-  #
-  #   class MultiplyThing < Actor
-  #     input :counter, default: 1
-  #     input :multiplier, default: -> { rand(1..10) }
-  #   end
-  module Defaultable
-    def self.included(base)
-      base.prepend(PrependedMethods)
-    end
+# Adds the `default:` option to inputs. Accepts regular values and lambdas.
+# If no default is set and the value has not been given, raises an error.
+#
+# Example:
+#
+#   class MultiplyThing < Actor
+#     input :counter, default: 1
+#     input :multiplier, default: -> { rand(1..10) }
+#   end
+module ServiceActor::Defaultable
+  def self.included(base)
+    base.prepend(PrependedMethods)
+  end
 
-    module PrependedMethods
-      def _call
-        self.class.inputs.each do |name, input|
-          next if result.key?(name)
+  module PrependedMethods
+    def _call
+      self.class.inputs.each do |name, input|
+        next if result.key?(name)
 
-          if input.key?(:default)
-            default = input[:default]
-            default = default.call if default.is_a?(Proc)
-            result[name] = default
-            next
-          end
-
-          raise(ArgumentError, "Input #{name} on #{self.class} is missing")
+        if input.key?(:default)
+          default = input[:default]
+          default = default.call if default.is_a?(Proc)
+          result[name] = default
+          next
         end
 
-        super
+        raise ServiceActor::ArgumentError,
+              "Input #{name} on #{self.class} is missing"
       end
+
+      super
     end
   end
 end

--- a/lib/service_actor/error.rb
+++ b/lib/service_actor/error.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Standard exception from which others inherit.
-  class Error < StandardError; end
-end
+# Standard exception from which others inherit.
+class ServiceActor::Error < StandardError; end

--- a/lib/service_actor/failable.rb
+++ b/lib/service_actor/failable.rb
@@ -1,40 +1,38 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Adds the `fail_on` DSL to actors. This allows you to call `.result` and get
-  # back a failed actor instead of raising an exception.
-  #
-  #   class ApplicationActor < Actor
-  #     fail_on ServiceActor::ArgumentError
-  #   end
-  module Failable
-    def self.included(base)
-      base.extend(ClassMethods)
-      base.prepend(PrependedMethods)
+# Adds the `fail_on` DSL to actors. This allows you to call `.result` and get
+# back a failed actor instead of raising an exception.
+#
+#   class ApplicationActor < Actor
+#     fail_on ServiceActor::ArgumentError
+#   end
+module ServiceActor::Failable
+  def self.included(base)
+    base.extend(ClassMethods)
+    base.prepend(PrependedMethods)
+  end
+
+  module ClassMethods
+    def inherited(child)
+      super
+
+      child.fail_ons.push(*fail_ons)
     end
 
-    module ClassMethods
-      def inherited(child)
-        super
-
-        child.fail_ons.push(*fail_ons)
-      end
-
-      def fail_on(*exceptions)
-        fail_ons.push(*exceptions)
-      end
-
-      def fail_ons
-        @fail_ons ||= []
-      end
+    def fail_on(*exceptions)
+      fail_ons.push(*exceptions)
     end
 
-    module PrependedMethods
-      def _call
-        super
-      rescue *self.class.fail_ons => e
-        fail!(error: e.message)
-      end
+    def fail_ons
+      @fail_ons ||= []
+    end
+  end
+
+  module PrependedMethods
+    def _call
+      super
+    rescue *self.class.fail_ons => e
+      fail!(error: e.message)
     end
   end
 end

--- a/lib/service_actor/failure.rb
+++ b/lib/service_actor/failure.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Error raised when using `fail!` inside an actor.
-  class Failure < Error
-    def initialize(result)
-      @result = result
+# Error raised when using `fail!` inside an actor.
+class ServiceActor::Failure < ServiceActor::Error
+  def initialize(result)
+    @result = result
 
-      error = result.respond_to?(:error) ? result.error : nil
+    error = result.respond_to?(:error) ? result.error : nil
 
-      super(error)
-    end
-
-    attr_reader :result
+    super(error)
   end
+
+  attr_reader :result
 end

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -1,46 +1,44 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Ensure your inputs and outputs are not nil by adding `allow_nil: false`.
-  #
-  # Example:
-  #
-  #   class CreateUser < Actor
-  #     input :name, allow_nil: false
-  #     output :user, allow_nil: false
-  #   end
-  module NilCheckable
-    def self.included(base)
-      base.prepend(PrependedMethods)
+# Ensure your inputs and outputs are not nil by adding `allow_nil: false`.
+#
+# Example:
+#
+#   class CreateUser < Actor
+#     input :name, allow_nil: false
+#     output :user, allow_nil: false
+#   end
+module ServiceActor::NilCheckable
+  def self.included(base)
+    base.prepend(PrependedMethods)
+  end
+
+  module PrependedMethods
+    def _call
+      check_context_for_nil(self.class.inputs, origin: "input")
+
+      super
+
+      check_context_for_nil(self.class.outputs, origin: "output")
     end
 
-    module PrependedMethods
-      def _call
-        check_context_for_nil(self.class.inputs, origin: "input")
+    private
 
-        super
+    def check_context_for_nil(definitions, origin:)
+      definitions.each do |name, options|
+        next if !result[name].nil? || allow_nil?(options)
 
-        check_context_for_nil(self.class.outputs, origin: "output")
+        raise ServiceActor::ArgumentError,
+              "The #{origin} \"#{name}\" on #{self.class} does not allow " \
+              "nil values"
       end
+    end
 
-      private
+    def allow_nil?(options)
+      return options[:allow_nil] if options.key?(:allow_nil)
+      return true if options.key?(:default) && options[:default].nil?
 
-      def check_context_for_nil(definitions, origin:)
-        definitions.each do |name, options|
-          next if !result[name].nil? || allow_nil?(options)
-
-          raise ArgumentError,
-                "The #{origin} \"#{name}\" on #{self.class} does not allow " \
-                "nil values"
-        end
-      end
-
-      def allow_nil?(options)
-        return options[:allow_nil] if options.key?(:allow_nil)
-        return true if options.key?(:default) && options[:default].nil?
-
-        !options[:type]
-      end
+      !options[:type]
     end
   end
 end

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -2,77 +2,75 @@
 
 require "ostruct"
 
-module ServiceActor
-  # Represents the context of an actor, holding the data from both its inputs
-  # and outputs.
-  class Result < OpenStruct
-    def self.to_result(data)
-      return data if data.is_a?(self)
+# Represents the context of an actor, holding the data from both its inputs
+# and outputs.
+class ServiceActor::Result < OpenStruct
+  def self.to_result(data)
+    return data if data.is_a?(self)
 
-      new(data.to_h)
+    new(data.to_h)
+  end
+
+  def inspect
+    "<#{self.class.name} #{to_h}>"
+  end
+
+  def fail!(result = {})
+    merge!(result)
+    merge!(failure?: true)
+
+    raise ServiceActor::Failure, self
+  end
+
+  def success?
+    !failure?
+  end
+
+  def failure?
+    self[:failure?] || false
+  end
+
+  def merge!(result)
+    result.each_pair do |key, value|
+      self[key] = value
     end
 
-    def inspect
-      "<#{self.class.name} #{to_h}>"
-    end
+    self
+  end
 
-    def fail!(result = {})
-      merge!(result)
-      merge!(failure?: true)
+  def key?(name)
+    to_h.key?(name)
+  end
 
-      raise Failure, self
-    end
+  def [](name)
+    to_h[name]
+  end
 
-    def success?
-      !failure?
-    end
+  # Defined here to override the method on `Object`.
+  def display
+    to_h.fetch(:display)
+  end
 
-    def failure?
-      self[:failure?] || false
-    end
+  private
 
-    def merge!(result)
-      result.each_pair do |key, value|
-        self[key] = value
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.end_with?("?") || super
+  end
+
+  def method_missing(symbol, *args)
+    attribute = symbol.to_s.chomp("?")
+
+    if symbol.to_s.end_with?("?") && respond_to?(attribute)
+      define_singleton_method symbol do
+        value = send(attribute.to_sym)
+
+        # Same as ActiveSupport’s #present?
+        value.respond_to?(:empty?) ? !value.empty? : !!value
       end
 
-      self
+      return send(symbol)
     end
 
-    def key?(name)
-      to_h.key?(name)
-    end
-
-    def [](name)
-      to_h[name]
-    end
-
-    # Defined here to override the method on `Object`.
-    def display
-      to_h.fetch(:display)
-    end
-
-    private
-
-    def respond_to_missing?(method_name, include_private = false)
-      method_name.to_s.end_with?("?") || super
-    end
-
-    def method_missing(symbol, *args)
-      attribute = symbol.to_s.chomp("?")
-
-      if symbol.to_s.end_with?("?") && respond_to?(attribute)
-        define_singleton_method symbol do
-          attribute_value = send(attribute.to_sym)
-
-          # Same as ActiveSupport’s #present?
-          attribute_value.respond_to?(:empty?) ? !attribute_value.empty? : !!attribute_value
-        end
-
-        return send(symbol)
-      end
-
-      super symbol, *args
-    end
+    super symbol, *args
   end
 end

--- a/lib/service_actor/support/loader.rb
+++ b/lib/service_actor/support/loader.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "zeitwerk"
+
+lib = File.expand_path("../..", __dir__)
+
+loader = Zeitwerk::Loader.new
+loader.tag = "service_actor"
+loader.inflector = Zeitwerk::GemInflector.new(
+  File.expand_path("service_actor.rb", lib),
+)
+loader.push_dir(lib)
+loader.ignore(__dir__)
+loader.setup
+
+module ServiceActor; end

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -1,50 +1,48 @@
 # frozen_string_literal: true
 
-module ServiceActor
-  # Adds `type:` checking to inputs and outputs. Accepts class names or classes
-  # that should match an ancestor. Also accepts arrays.
-  #
-  # Example:
-  #
-  #   class ReduceOrderAmount < Actor
-  #     input :order, type: "Order"
-  #     input :amount, type: [Integer, Float]
-  #     input :bonus_applied, type: [TrueClass FalseClass]
-  #   end
-  module TypeCheckable
-    def self.included(base)
-      base.prepend(PrependedMethods)
+# Adds `type:` checking to inputs and outputs. Accepts class names or classes
+# that should match an ancestor. Also accepts arrays.
+#
+# Example:
+#
+#   class ReduceOrderAmount < Actor
+#     input :order, type: "Order"
+#     input :amount, type: [Integer, Float]
+#     input :bonus_applied, type: [TrueClass FalseClass]
+#   end
+module ServiceActor::TypeCheckable
+  def self.included(base)
+    base.prepend(PrependedMethods)
+  end
+
+  module PrependedMethods
+    def _call
+      check_type_definitions(self.class.inputs, kind: "Input")
+
+      super
+
+      check_type_definitions(self.class.outputs, kind: "Output")
     end
 
-    module PrependedMethods
-      def _call
-        check_type_definitions(self.class.inputs, kind: "Input")
+    private
 
-        super
+    def check_type_definitions(definitions, kind:)
+      definitions.each do |key, options|
+        type_definition = options[:type] || next
+        value = result[key] || next
 
-        check_type_definitions(self.class.outputs, kind: "Output")
+        types = types_for_definition(type_definition)
+        next if types.any? { |type| value.is_a?(type) }
+
+        raise ServiceActor::ArgumentError,
+              "#{kind} #{key} on #{self.class} must be of type " \
+              "#{types.join(', ')} but was #{value.class}"
       end
+    end
 
-      private
-
-      def check_type_definitions(definitions, kind:)
-        definitions.each do |key, options|
-          type_definition = options[:type] || next
-          value = result[key] || next
-
-          types = types_for_definition(type_definition)
-          next if types.any? { |type| value.is_a?(type) }
-
-          raise ArgumentError,
-                "#{kind} #{key} on #{self.class} must be of type " \
-                "#{types.join(', ')} but was #{value.class}"
-        end
-      end
-
-      def types_for_definition(type_definition)
-        Array(type_definition).map do |name|
-          name.is_a?(String) ? Object.const_get(name) : name
-        end
+    def types_for_definition(type_definition)
+      Array(type_definition).map do |name|
+        name.is_a?(String) ? Object.const_get(name) : name
       end
     end
   end

--- a/service_actor.gemspec
+++ b/service_actor.gemspec
@@ -34,6 +34,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = [">= 2.4"]
 
+  # Loader
+  spec.add_runtime_dependency "zeitwerk"
+
   # Tests
   spec.add_development_dependency "rspec"
 

--- a/spec/examples/fail_playing_actions.rb
+++ b/spec/examples/fail_playing_actions.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./increment_value"
-require_relative "./fail_with_error"
-
 class FailPlayingActions < Actor
   input :value, type: Integer
   output :value, type: String

--- a/spec/examples/fail_playing_actions_with_rollback.rb
+++ b/spec/examples/fail_playing_actions_with_rollback.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./add_name_to_context"
-require_relative "./increment_value_with_rollback"
-require_relative "./fail_with_error"
-
 class FailPlayingActionsWithRollback < Actor
   input :value, type: Integer
   output :value, type: Integer

--- a/spec/examples/inherit_from_increment_value.rb
+++ b/spec/examples/inherit_from_increment_value.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./increment_value"
-
 class InheritFromIncrementValue < IncrementValue
   def call
     super

--- a/spec/examples/inherit_from_play.rb
+++ b/spec/examples/inherit_from_play.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./play_actors"
-
 class InheritFromPlay < PlayActors
   play IncrementValue
 end

--- a/spec/examples/play_actors.rb
+++ b/spec/examples/play_actors.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./increment_value"
-require_relative "./do_nothing"
-require_relative "./add_name_to_context"
-require_relative "./set_name_to_downcase"
-require_relative "./use_stripped_down_actor"
-
 class PlayActors < Actor
   play IncrementValue,
        DoNothing,

--- a/spec/examples/play_error_and_catch_it_in_rollback.rb
+++ b/spec/examples/play_error_and_catch_it_in_rollback.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./catch_error_in_rollback"
-require_relative "./fail_with_error"
-
 class PlayErrorAndCatchItInRollback < Actor
   play CatchErrorInRollback,
        FailWithError

--- a/spec/examples/play_instance_methods.rb
+++ b/spec/examples/play_instance_methods.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./increment_value"
-require_relative "./set_name_to_downcase"
-
 class PlayInstanceMethods < Actor
   output :value, type: Integer
   output :name, type: String

--- a/spec/examples/play_interactor.rb
+++ b/spec/examples/play_interactor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./increment_value_with_interactor"
-
 class PlayInteractor < Actor
   input :value, default: 1
   output :value

--- a/spec/examples/play_lambdas.rb
+++ b/spec/examples/play_lambdas.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./increment_value"
-require_relative "./set_name_to_downcase"
-
 class PlayLambdas < Actor
   output :name, type: String
 

--- a/spec/examples/play_multiple_times.rb
+++ b/spec/examples/play_multiple_times.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./increment_value"
-require_relative "./do_nothing"
-require_relative "./add_name_to_context"
-require_relative "./set_name_to_downcase"
-
 class PlayMultipleTimes < Actor
   input :value, default: 1
   output :value

--- a/spec/examples/play_multiple_times_with_conditions.rb
+++ b/spec/examples/play_multiple_times_with_conditions.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./add_name_to_context"
-require_relative "./increment_value"
-require_relative "./fail_with_error"
-
 class PlayMultipleTimesWithConditions < Actor
   input :value, default: 1
 

--- a/spec/service_actor/base_spec.rb
+++ b/spec/service_actor/base_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe ServiceActor::Base do
+  it "can be used to build your own actor" do
+    actor = InheritFromCustomBase.call(value: 41)
+
+    expect(actor.value).to eq(42)
+  end
+end

--- a/spec/service_actor/version_spec.rb
+++ b/spec/service_actor/version_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe ServiceActor::VERSION do
+  # rubocop:disable RSpec/DescribedClass
+  it { expect(ServiceActor::VERSION).not_to be_nil }
+  # rubocop:enable RSpec/DescribedClass
+end

--- a/spec/service_actor_spec.rb
+++ b/spec/service_actor_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe ServiceActor do
+  describe "eager loading" do
+    it "does not raise" do
+      Zeitwerk::Loader.eager_load_all
+    end
+  end
+
   describe "::VERSION" do
     it { expect(ServiceActor::VERSION).not_to be_nil }
   end

--- a/spec/service_actor_spec.rb
+++ b/spec/service_actor_spec.rb
@@ -1,21 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ServiceActor do
-  describe "eager loading" do
-    it "does not raise" do
-      Zeitwerk::Loader.eager_load_all
-    end
-  end
-
-  describe "::VERSION" do
-    it { expect(ServiceActor::VERSION).not_to be_nil }
-  end
-
-  describe "::Base" do
-    it "can be used to build your own actor" do
-      actor = InheritFromCustomBase.call(value: 41)
-
-      expect(actor.value).to eq(42)
-    end
+  it "does not raise on eager load" do
+    Zeitwerk::Loader.eager_load_all
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,10 @@ require "bundler/setup"
 require "service_actor"
 require "pry"
 
-Dir["./spec/examples/*"].sort.each { |f| require f }
+# Autoload examples
+loader = Zeitwerk::Loader.new
+loader.push_dir(File.expand_path("examples", __dir__))
+loader.setup
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Replace maintaining a list of `require` statements by using the Zeitwerk gem which autoloads classes by their path.

This also uses switches to using the compact style for defining classes and modules in Ruby.

This introduces a dependency to the `zeitwerk` gem.