### PR TITLE
Add support for custom error messages to `input` and `output`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,7 +45,7 @@ Metrics/MethodLength:
     - service_actor.gemspec
 
 RSpec/NestedGroups:
-  Max: 4
+  Max: 5
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ end
     input :provider,
           inclusion: {
             in: ["MANGOPAY", "PayPal", "Stripe"],
-            message: (lambda do |input_key:, inclusion_in:, value:|
+            message: (lambda do |input_key:, actor:, inclusion_in:, value:|
               "Payment system \"#{value}\" is not supported"
             end)
           }

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ class UpdateUser < Actor
   input :user,
         allow_nil: {
           is: false,
-          message: (lambda do |_origin, input_key, _service_name|
+          message: (lambda do |_origin:, input_key:, _service_name:|
             "The value `#{input_key}` cannot be empty"
           end)
         }
@@ -296,7 +296,7 @@ end
     input :provider,
           inclusion: {
             in: ["MANGOPAY", "PayPal", "Stripe"],
-            message: (lambda do |_input_key, _inclusion_in, value|
+            message: (lambda do |_input_key:, _inclusion_in:, value:|
               "Payment system \"#{value}\" is not supported"
             end)
           }
@@ -311,7 +311,7 @@ end
           must: {
             exist: {
               is: -> provider { PROVIDERS.include?(provider) },
-              message: (lambda do |_input_key, _check_name, value|
+              message: (lambda do |_input_key:, _check_name:, value:|
                 "The specified provider \"#{value}\" was not found."
               end)
             }
@@ -326,7 +326,7 @@ end
     input :multiplier,
           default: {
             is: -> { rand(1..10) },
-            message: (lambda do |input_key, _service_name|
+            message: (lambda do |input_key:, _service_name:|
               "Input `#{input_key}` is required"
             end)
           }
@@ -340,7 +340,7 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
+            message: (lambda do |_kind:, input_key:, _service_name:, expected_type_names:, actual_type_name:|
               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
               "Expected: `#{expected_type_names}`"
             end)
@@ -355,7 +355,7 @@ end
     input :name,
           allow_nil: {
             is: false,
-            message: (lambda do |_origin, _input_key, _service_name|
+            message: (lambda do |_origin:, input_key:, _service_name:|
               "The value `#{input_key}` cannot be empty"
             end)
           }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ and controllers thin.
   - [Conditions](#conditions)
   - [Types](#types)
   - [Fail](#fail)
+  - [Advanced mode](#advanced-mode)
 - [Play actors in a sequence](#play-actors-in-a-sequence)
   - [Rollback](#rollback)
   - [Inline actors](#inline-actors)
@@ -247,6 +248,43 @@ class UsersController < ApplicationController
       render :new, notice: actor.error
     end
   end
+end
+```
+
+### Advanced mode
+
+If you need to prepare custom error messages, you can use "advanced mode".
+
+This mode is enabled automatically when using `Hash` as the passed value.
+An example of using this approach:
+
+```rb
+class UpdateAdminUser < Actor
+  input :user,
+        must: {
+          be_an_admin: {
+            is: -> user { user.admin? },
+            message: "The user is not an administrator"
+          }
+        }
+
+  # ...
+end
+```
+
+You can also use incoming arguments when shaping your error text:
+
+```rb
+class UpdateUser < Actor
+  input :user,
+        allow_nil: {
+          is: false,
+          message: (lambda do |_origin, input_key, _service_name|
+            "The value `#{input_key}` cannot be empty"
+          end)
+        }
+
+  # ...
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -251,12 +251,10 @@ class UsersController < ApplicationController
 end
 ```
 
-### Advanced mode
+### Custom input errors
 
-If you need to prepare custom error messages, you can use "advanced mode".
-
-This mode is enabled automatically when using `Hash` as the passed value.
-An example of using this approach:
+Use a `Hash` with `is:` and `message:` keys to prepare custom
+error messages on inputs. For example:
 
 ```rb
 class UpdateAdminUser < Actor

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and controllers thin.
   - [Conditions](#conditions)
   - [Types](#types)
   - [Fail](#fail)
-  - [Advanced mode](#advanced-mode)
+  - [Custom input errors](#custom-input-errors)
 - [Play actors in a sequence](#play-actors-in-a-sequence)
   - [Rollback](#rollback)
   - [Inline actors](#inline-actors)

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ class UpdateUser < Actor
   input :user,
         allow_nil: {
           is: false,
-          message: (lambda do |origin:, input_key:, service_name:|
+          message: (lambda do |origin:, input_key:, actor:|
             "The value `#{input_key}` cannot be empty"
           end)
         }
@@ -326,7 +326,7 @@ end
     input :multiplier,
           default: {
             is: -> { rand(1..10) },
-            message: (lambda do |input_key:, service_name:|
+            message: (lambda do |input_key:, actor:|
               "Input `#{input_key}` is required"
             end)
           }
@@ -340,7 +340,7 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |kind:, input_key:, service_name:, expected_type:, given_type:|
+            message: (lambda do |kind:, input_key:, actor:, expected_type:, given_type:|
               "Wrong type `#{given_type}` for `#{input_key}`. " \
               "Expected: `#{expected_type}`"
             end)
@@ -355,7 +355,7 @@ end
     input :name,
           allow_nil: {
             is: false,
-            message: (lambda do |origin:, input_key:, service_name:|
+            message: (lambda do |origin:, input_key:, actor:|
               "The value `#{input_key}` cannot be empty"
             end)
           }

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ end
           must: {
             exist: {
               is: -> provider { PROVIDERS.include?(provider) },
-              message: (lambda do |_input_key:, _check_name:, value:|
+              message: (lambda do |input_key:, check_name:, value:|
                 "The specified provider \"#{value}\" was not found."
               end)
             }
@@ -326,7 +326,7 @@ end
     input :multiplier,
           default: {
             is: -> { rand(1..10) },
-            message: (lambda do |input_key:, _service_name:|
+            message: (lambda do |input_key:, service_name:|
               "Input `#{input_key}` is required"
             end)
           }
@@ -340,7 +340,7 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |_kind:, input_key:, _service_name:, expected_type_names:, actual_type_name:|
+            message: (lambda do |kind:, input_key:, service_name:, expected_type_names:, actual_type_name:|
               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
               "Expected: `#{expected_type_names}`"
             end)
@@ -355,7 +355,7 @@ end
     input :name,
           allow_nil: {
             is: false,
-            message: (lambda do |_origin:, input_key:, _service_name:|
+            message: (lambda do |origin:, input_key:, service_name:|
               "The value `#{input_key}` cannot be empty"
             end)
           }

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ class UpdateUser < Actor
   input :user,
         allow_nil: {
           is: false,
-          message: (lambda do |origin:, input_key:, actor:|
+          message: (lambda do |input_key:, **|
             "The value \"#{input_key}\" cannot be empty"
           end)
         }
@@ -296,7 +296,7 @@ end
     input :provider,
           inclusion: {
             in: ["MANGOPAY", "PayPal", "Stripe"],
-            message: (lambda do |input_key:, actor:, inclusion_in:, value:|
+            message: (lambda do |value:, **|
               "Payment system \"#{value}\" is not supported"
             end)
           }
@@ -311,7 +311,7 @@ end
           must: {
             exist: {
               is: -> provider { PROVIDERS.include?(provider) },
-              message: (lambda do |input_key:, check_name:, actor:, value:|
+              message: (lambda do |value:, **|
                 "The specified provider \"#{value}\" was not found."
               end)
             }
@@ -326,7 +326,7 @@ end
     input :multiplier,
           default: {
             is: -> { rand(1..10) },
-            message: (lambda do |input_key:, actor:|
+            message: (lambda do |input_key:, **|
               "Input \"#{input_key}\" is required"
             end)
           }
@@ -340,7 +340,7 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |origin:, input_key:, actor:, expected_type:, given_type:|
+            message: (lambda do |input_key:, expected_type:, given_type, **|
               "Wrong type \"#{given_type}\" for \"#{input_key}\". " \
               "Expected: \"#{expected_type}\""
             end)
@@ -355,7 +355,7 @@ end
     input :name,
           allow_nil: {
             is: false,
-            message: (lambda do |origin:, input_key:, actor:|
+            message: (lambda do |input_key:, **|
               "The value \"#{input_key}\" cannot be empty"
             end)
           }

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ class UpdateUser < Actor
   input :user,
         allow_nil: {
           is: false,
-          message: (lambda do |_origin:, input_key:, _service_name:|
+          message: (lambda do |origin:, input_key:, service_name:|
             "The value `#{input_key}` cannot be empty"
           end)
         }

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ end
     input :provider,
           inclusion: {
             in: ["MANGOPAY", "PayPal", "Stripe"],
-            message: (lambda do |_input_key, value, _inclusion_in|
+            message: (lambda do |_input_key, _inclusion_in, value|
               "Payment system \"#{value}\" is not supported"
             end)
           }
@@ -340,7 +340,7 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
+            message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
               "Expected: `#{expected_type_names}`"
             end)

--- a/README.md
+++ b/README.md
@@ -340,9 +340,9 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |kind:, input_key:, service_name:, expected_type_names:, actual_type_name:|
-              "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
-              "Expected: `#{expected_type_names}`"
+            message: (lambda do |kind:, input_key:, service_name:, expected_type:, given_type:|
+              "Wrong type `#{given_type}` for `#{input_key}`. " \
+              "Expected: `#{expected_type}`"
             end)
           }
   end

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ end
           must: {
             exist: {
               is: -> provider { PROVIDERS.include?(provider) },
-              message: (lambda do |input_key:, check_name:, value:|
+              message: (lambda do |input_key:, check_name:, actor:, value:|
                 "The specified provider \"#{value}\" was not found."
               end)
             }

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ end
     input :provider,
           inclusion: {
             in: ["MANGOPAY", "PayPal", "Stripe"],
-            message: (lambda do |_input_key:, _inclusion_in:, value:|
+            message: (lambda do |input_key:, inclusion_in:, value:|
               "Payment system \"#{value}\" is not supported"
             end)
           }

--- a/README.md
+++ b/README.md
@@ -288,6 +288,84 @@ class UpdateUser < Actor
 end
 ```
 
+<details>
+  <summary>Display full examples with all arguments</summary>
+
+  #### Inclusion
+
+  ```ruby
+  class Pay < Actor
+    input :provider,
+          inclusion: {
+            in: ["MANGOPAY", "PayPal", "Stripe"],
+            message: (lambda do |_input_key, value, _inclusion_in|
+              "Payment system \"#{value}\" is not supported"
+            end)
+          }
+  end
+  ```
+
+  #### Must
+
+  ```ruby
+  class Pay < Actor
+    input :provider,
+          must: {
+            exist: {
+              is: -> provider { PROVIDERS.include?(provider) },
+              message: (lambda do |_input_key, _check_name, value|
+                "The specified provider \"#{value}\" was not found."
+              end)
+            }
+          }
+  end
+  ```
+
+  #### Default
+
+  ```ruby
+  class MultiplyThing < Actor
+    input :multiplier,
+          default: {
+            is: -> { rand(1..10) },
+            message: (lambda do |input_key, _service_name|
+              "Input `#{input_key}` is required"
+            end)
+          }
+  end
+  ```
+
+  #### Type
+
+  ```ruby
+  class ReduceOrderAmount < Actor
+    input :bonus_applied,
+          type: {
+            is: [TrueClass, FalseClass],
+            message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
+              "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
+              "Expected: `#{expected_type_names}`"
+            end)
+          }
+  end
+  ```
+
+  #### Allow nil
+
+  ```ruby
+  class CreateUser < Actor
+    input :name,
+          allow_nil: {
+            is: false,
+            message: (lambda do |_origin, _input_key, _service_name|
+              "The value `#{input_key}` cannot be empty"
+            end)
+          }
+  end
+  ```
+
+</details>
+
 ## Play actors in a sequence
 
 To help you create actors that are small, single-responsibility actions, an

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |input_key:, expected_type:, given_type, **|
+            message: (lambda do |input_key:, expected_type:, given_type:, **|
               "Wrong type \"#{given_type}\" for \"#{input_key}\". " \
               "Expected: \"#{expected_type}\""
             end)

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ class UpdateUser < Actor
         allow_nil: {
           is: false,
           message: (lambda do |origin:, input_key:, actor:|
-            "The value `#{input_key}` cannot be empty"
+            "The value \"#{input_key}\" cannot be empty"
           end)
         }
 
@@ -327,7 +327,7 @@ end
           default: {
             is: -> { rand(1..10) },
             message: (lambda do |input_key:, actor:|
-              "Input `#{input_key}` is required"
+              "Input \"#{input_key}\" is required"
             end)
           }
   end
@@ -341,8 +341,8 @@ end
           type: {
             is: [TrueClass, FalseClass],
             message: (lambda do |origin:, input_key:, actor:, expected_type:, given_type:|
-              "Wrong type `#{given_type}` for `#{input_key}`. " \
-              "Expected: `#{expected_type}`"
+              "Wrong type \"#{given_type}\" for \"#{input_key}\". " \
+              "Expected: \"#{expected_type}\""
             end)
           }
   end
@@ -356,7 +356,7 @@ end
           allow_nil: {
             is: false,
             message: (lambda do |origin:, input_key:, actor:|
-              "The value `#{input_key}` cannot be empty"
+              "The value \"#{input_key}\" cannot be empty"
             end)
           }
   end

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ end
     input :bonus_applied,
           type: {
             is: [TrueClass, FalseClass],
-            message: (lambda do |kind:, input_key:, actor:, expected_type:, given_type:|
+            message: (lambda do |origin:, input_key:, actor:, expected_type:, given_type:|
               "Wrong type `#{given_type}` for `#{input_key}`. " \
               "Expected: `#{expected_type}`"
             end)

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -13,7 +13,7 @@
 #     input :provider,
 #           inclusion: {
 #             in: ["MANGOPAY", "PayPal", "Stripe"],
-#             message: (lambda do |_input_key, value, _inclusion_in|
+#             message: (lambda do |_input_key, _inclusion_in, value|
 #               "Payment system \"#{value}\" is not supported"
 #             end)
 #           }
@@ -24,7 +24,7 @@ module ServiceActor::Collectionable
   end
 
   module PrependedMethods
-    DEFAULT_MESSAGE = lambda do |input_key, value, inclusion_in|
+    DEFAULT_MESSAGE = lambda do |input_key, inclusion_in, value|
       "Input #{input_key} must be included " \
       "in #{inclusion_in.inspect} but instead " \
       "was #{value.inspect}"
@@ -39,11 +39,6 @@ module ServiceActor::Collectionable
         # DEPRECATED: `in` is deprecated in favor of `inclusion`.
         inclusion = options[:inclusion] || options[:in]
 
-        base_arguments = {
-          input_key: key,
-          value: value
-        }
-
         inclusion_in, message = define_inclusion_from(inclusion)
 
         next if inclusion_in.nil?
@@ -51,8 +46,9 @@ module ServiceActor::Collectionable
 
         raise_error_with(
           message,
-          **base_arguments,
+          input_key: key,
           inclusion_in: inclusion_in,
+          value: value,
         )
       end
 

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -13,7 +13,7 @@
 #     input :provider,
 #           inclusion: {
 #             in: ["MANGOPAY", "PayPal", "Stripe"],
-#             message: (lambda do |_input_key:, _inclusion_in:, value:|
+#             message: (lambda do |input_key:, inclusion_in:, value:|
 #               "Payment system \"#{value}\" is not supported"
 #             end)
 #           }

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -13,7 +13,7 @@
 #     input :provider,
 #           inclusion: {
 #             in: ["MANGOPAY", "PayPal", "Stripe"],
-#             message: (lambda do |input_key:, inclusion_in:, value:|
+#             message: (lambda do |input_key:, actor:, inclusion_in:, value:|
 #               "Payment system \"#{value}\" is not supported"
 #             end)
 #           }
@@ -24,10 +24,10 @@ module ServiceActor::Collectionable
   end
 
   module PrependedMethods
-    DEFAULT_MESSAGE = lambda do |input_key:, inclusion_in:, value:|
-      "Input #{input_key} must be included " \
-      "in #{inclusion_in.inspect} but instead " \
-      "was #{value.inspect}"
+    DEFAULT_MESSAGE = lambda do |input_key:, actor:, inclusion_in:, value:|
+      "The input #{input_key} must be included " \
+      "in #{inclusion_in.inspect} on #{actor} " \
+      "instead of #{value.inspect}"
     end
 
     private_constant :DEFAULT_MESSAGE
@@ -47,6 +47,7 @@ module ServiceActor::Collectionable
         raise_error_with(
           message,
           input_key: key,
+          actor: self.class,
           inclusion_in: inclusion_in,
           value: value,
         )

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -28,13 +28,14 @@ module ServiceActor::Collectionable
       self.class.inputs.each do |key, options|
         inclusion = options[:inclusion]
 
+        message = "Input #{key} must be included " \
+                  "in #{inclusion.inspect} but instead " \
+                  "was #{result[key].inspect}"
+
         if inclusion.is_a?(Hash) # advanced mode
           inclusion_in, message = inclusion.values_at(:in, :message)
         else
           inclusion_in = inclusion
-          message = "Input #{key} must be included " \
-                    "in #{inclusion.inspect} but instead " \
-                    "was #{result[key].inspect}"
         end
 
         next if inclusion_in.nil?

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -25,8 +25,8 @@ module ServiceActor::Collectionable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do |input_key:, actor:, inclusion_in:, value:|
-      "The #{input_key} input must be included " \
-      "in #{inclusion_in.inspect} on #{actor} " \
+      "The \"#{input_key}\" input must be included " \
+      "in #{inclusion_in.inspect} on \"#{actor}\" " \
       "instead of #{value.inspect}"
     end
 

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -13,7 +13,7 @@
 #     input :provider,
 #           inclusion: {
 #             in: ["MANGOPAY", "PayPal", "Stripe"],
-#             message: (lambda do |_input_key:, _inclusion_in_, value:|
+#             message: (lambda do |_input_key:, _inclusion_in:, value:|
 #               "Payment system \"#{value}\" is not supported"
 #             end)
 #           }

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -13,7 +13,7 @@
 #     input :provider,
 #           inclusion: {
 #             in: ["MANGOPAY", "PayPal", "Stripe"],
-#             message: (lambda do |_input_key, _inclusion_in, value|
+#             message: (lambda do |_input_key:, _inclusion_in_, value:|
 #               "Payment system \"#{value}\" is not supported"
 #             end)
 #           }
@@ -24,7 +24,7 @@ module ServiceActor::Collectionable
   end
 
   module PrependedMethods
-    DEFAULT_MESSAGE = lambda do |input_key, inclusion_in, value|
+    DEFAULT_MESSAGE = lambda do |input_key:, inclusion_in:, value:|
       "Input #{input_key} must be included " \
       "in #{inclusion_in.inspect} but instead " \
       "was #{value.inspect}"

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -13,7 +13,7 @@
 #     input :provider,
 #           inclusion: {
 #             in: ["MANGOPAY", "PayPal", "Stripe"],
-#             message: (lambda do |_input_key, _in, value|
+#             message: (lambda do |_input_key, _inclusion_in, value|
 #               "Payment system \"#{value}\" is not supported"
 #             end)
 #           }
@@ -41,13 +41,12 @@ module ServiceActor::Collectionable
         next if inclusion_in.nil?
         next if inclusion_in.include?(result[key])
 
-        error_text = if message.is_a?(Proc)
-                       message.call(key, inclusion, result[key])
-                     else
-                       message
-                     end
-
-        raise ArgumentError, error_text
+        raise_error_with(
+          message,
+          input_key: key,
+          inclusion_in: inclusion_in,
+          value: result[key],
+        )
       end
 
       super

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -13,7 +13,7 @@
 #     input :provider,
 #           inclusion: {
 #             in: ["MANGOPAY", "PayPal", "Stripe"],
-#             message: (lambda do |_input_key, _inclusion_in, value|
+#             message: (lambda do |_input_key, value, _inclusion_in|
 #               "Payment system \"#{value}\" is not supported"
 #             end)
 #           }
@@ -29,21 +29,21 @@ module ServiceActor::Collectionable
         value = result[key]
         inclusion = options[:inclusion]
 
-        # FIXME: The `prototype_1_with` method needs to be renamed.
-        inclusion_in, message = prototype_1_with(
-          inclusion,
+        base_arguments = {
           input_key: key,
-          value: value,
-        )
+          value: value
+        }
+
+        # FIXME: The `prototype_1_with` method needs to be renamed.
+        inclusion_in, message = prototype_1_with(inclusion, **base_arguments)
 
         next if inclusion_in.nil?
         next if inclusion_in.include?(value)
 
         raise_error_with(
           message,
-          input_key: key,
+          **base_arguments,
           inclusion_in: inclusion_in,
-          value: value,
         )
       end
 

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -34,8 +34,8 @@ module ServiceActor::Collectionable
           value: value
         }
 
-        # FIXME: The `prototype_1_with` method needs to be renamed.
-        inclusion_in, message = prototype_1_with(inclusion, **base_arguments)
+        inclusion_in, message =
+          define_inclusion_with(inclusion, **base_arguments)
 
         next if inclusion_in.nil?
         next if inclusion_in.include?(value)
@@ -52,8 +52,7 @@ module ServiceActor::Collectionable
 
     private
 
-    # FIXME: The `prototype_1_with` method needs to be renamed.
-    def prototype_1_with(inclusion, input_key:, value:)
+    def define_inclusion_with(inclusion, input_key:, value:)
       if inclusion.is_a?(Hash) # advanced mode
         inclusion_in, message = inclusion.values_at(:in, :message)
       else

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -62,18 +62,11 @@ module ServiceActor::Collectionable
     private
 
     def define_inclusion_from(inclusion)
-      message = DEFAULT_MESSAGE
-
-      if inclusion.is_a?(Hash) # advanced mode
-        inclusion_in, message = inclusion.values_at(:in, :message)
+      if inclusion.is_a?(Hash)
+        inclusion.values_at(:in, :message)
       else
-        inclusion_in = inclusion
+        [inclusion, DEFAULT_MESSAGE]
       end
-
-      [
-        inclusion_in,
-        message
-      ]
     end
   end
 end

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -25,7 +25,7 @@ module ServiceActor::Collectionable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do |input_key:, actor:, inclusion_in:, value:|
-      "The input #{input_key} must be included " \
+      "The #{input_key} input must be included " \
       "in #{inclusion_in.inspect} on #{actor} " \
       "instead of #{value.inspect}"
     end

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -52,6 +52,7 @@ module ServiceActor::Collectionable
 
     private
 
+    # FIXME: The `prototype_1_with` method needs to be renamed.
     def prototype_1_with(inclusion, input_key:, value:)
       if inclusion.is_a?(Hash) # advanced mode
         inclusion_in, message = inclusion.values_at(:in, :message)

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -62,6 +62,7 @@ module ServiceActor::Conditionable
 
     private
 
+    # FIXME: The `prototype_2_with` method needs to be renamed.
     def prototype_2_with(check, input_key:, check_name:, value:)
       if check.is_a?(Hash) # advanced mode
         check, message = check.values_at(:state, :message)

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -35,16 +35,16 @@ module ServiceActor::Conditionable
       self.class.inputs.each do |key, options|
         next unless options[:must]
 
-        options[:must].each do |check_name, content|
+        options[:must].each do |check_name, check|
           value = result[key]
 
-          message = "Input #{key} must #{check_name} but was #{value.inspect}"
-
-          if content.is_a?(Hash) # advanced mode
-            check, message = content.values_at(:state, :message)
-          else
-            check = content
-          end
+          # FIXME: The `prototype_2_with` method needs to be renamed.
+          check, message = prototype_2_with(
+            check,
+            input_key: key,
+            check_name: check_name,
+            value: value,
+          )
 
           next if check.call(value)
 
@@ -58,6 +58,22 @@ module ServiceActor::Conditionable
       end
 
       super
+    end
+
+    private
+
+    def prototype_2_with(check, input_key:, check_name:, value:)
+      if check.is_a?(Hash) # advanced mode
+        check, message = check.values_at(:state, :message)
+      else
+        message =
+          "Input #{input_key} must #{check_name} but was #{value.inspect}"
+      end
+
+      [
+        check,
+        message
+      ]
     end
   end
 end

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -19,7 +19,7 @@
 #           must: {
 #             exist: {
 #               is: -> provider { PROVIDERS.include?(provider) },
-#               message: (lambda do |_input_key:, _check_name:, value:|
+#               message: (lambda do |input_key:, check_name:, value:|
 #                 "The specified provider \"#{value}\" was not found."
 #               end)
 #             }

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -44,12 +44,6 @@ module ServiceActor::Conditionable
         options[:must].each do |check_name, check|
           value = result[key]
 
-          base_arguments = {
-            input_key: key,
-            check_name: check_name,
-            value: value
-          }
-
           check, message = define_check_from(check)
 
           next if check.call(value)

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -44,8 +44,7 @@ module ServiceActor::Conditionable
             value: value
           }
 
-          # FIXME: The `prototype_2_with` method needs to be renamed.
-          check, message = prototype_2_with(check, **base_arguments)
+          check, message = define_check_with(check, **base_arguments)
 
           next if check.call(value)
 
@@ -58,8 +57,7 @@ module ServiceActor::Conditionable
 
     private
 
-    # FIXME: The `prototype_2_with` method needs to be renamed.
-    def prototype_2_with(check, input_key:, check_name:, value:)
+    def define_check_with(check, input_key:, check_name:, value:)
       if check.is_a?(Hash) # advanced mode
         check, message = check.values_at(:state, :message)
       else

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -64,15 +64,11 @@ module ServiceActor::Conditionable
     private
 
     def define_check_from(check)
-      message = DEFAULT_MESSAGE
-
-      # advanced mode
-      check, message = check.values_at(:is, :message) if check.is_a?(Hash)
-
-      [
-        check,
-        message
-      ]
+      if check.is_a?(Hash)
+        check.values_at(:is, :message)
+      else
+        [check, DEFAULT_MESSAGE]
+      end
     end
   end
 end

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -19,7 +19,7 @@
 #           must: {
 #             exist: {
 #               is: -> provider { PROVIDERS.include?(provider) },
-#               message: (lambda do |_input_key, _check_name, value|
+#               message: (lambda do |_input_key:, _check_name:, value:|
 #                 "The specified provider \"#{value}\" was not found."
 #               end)
 #             }
@@ -31,7 +31,7 @@ module ServiceActor::Conditionable
   end
 
   module PrependedMethods
-    DEFAULT_MESSAGE = lambda do |input_key, check_name, value|
+    DEFAULT_MESSAGE = lambda do |input_key:, check_name:, value:|
       "Input #{input_key} must #{check_name} but was #{value.inspect}"
     end
 

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -38,22 +38,18 @@ module ServiceActor::Conditionable
         options[:must].each do |check_name, check|
           value = result[key]
 
-          # FIXME: The `prototype_2_with` method needs to be renamed.
-          check, message = prototype_2_with(
-            check,
+          base_arguments = {
             input_key: key,
             check_name: check_name,
-            value: value,
-          )
+            value: value
+          }
+
+          # FIXME: The `prototype_2_with` method needs to be renamed.
+          check, message = prototype_2_with(check, **base_arguments)
 
           next if check.call(value)
 
-          raise_error_with(
-            message,
-            input_key: key,
-            check_name: check_name,
-            value: value,
-          )
+          raise_error_with(message, **base_arguments)
         end
       end
 

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -38,11 +38,12 @@ module ServiceActor::Conditionable
         options[:must].each do |name, content|
           value = result[key]
 
+          message = "Input #{key} must #{name} but was #{value.inspect}"
+
           if content.is_a?(Hash) # advanced mode
             check, message = content.values_at(:state, :message)
           else
             check = content
-            message = "Input #{key} must #{name} but was #{value.inspect}"
           end
 
           next if check.call(value)

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -48,7 +48,12 @@ module ServiceActor::Conditionable
 
           next if check.call(value)
 
-          raise_error_with(message, **base_arguments)
+          raise_error_with(
+            message,
+            input_key: key,
+            check_name: check_name,
+            value: value,
+          )
         end
       end
 

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -19,7 +19,7 @@
 #           must: {
 #             exist: {
 #               is: -> provider { PROVIDERS.include?(provider) },
-#               message: (lambda do |input_key:, check_name:, value:|
+#               message: (lambda do |input_key:, check_name:, actor:, value:|
 #                 "The specified provider \"#{value}\" was not found."
 #               end)
 #             }

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -31,8 +31,9 @@ module ServiceActor::Conditionable
   end
 
   module PrependedMethods
-    DEFAULT_MESSAGE = lambda do |input_key:, check_name:, value:|
-      "Input #{input_key} must #{check_name} but was #{value.inspect}"
+    DEFAULT_MESSAGE = lambda do |input_key:, check_name:, actor:, value:|
+      "The #{input_key} input on #{actor} must #{check_name} " \
+        "but was #{value.inspect}"
     end
 
     private_constant :DEFAULT_MESSAGE
@@ -52,6 +53,7 @@ module ServiceActor::Conditionable
             message,
             input_key: key,
             check_name: check_name,
+            actor: self.class,
             value: value,
           )
         end

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -32,7 +32,7 @@ module ServiceActor::Conditionable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do |input_key:, check_name:, actor:, value:|
-      "The #{input_key} input on #{actor} must #{check_name} " \
+      "The \"#{input_key}\" input on \"#{actor}\" must \"#{check_name}\" " \
         "but was #{value.inspect}"
     end
 

--- a/lib/service_actor/conditionable.rb
+++ b/lib/service_actor/conditionable.rb
@@ -18,7 +18,7 @@
 #     input :provider,
 #           must: {
 #             exist: {
-#               state: -> provider { PROVIDERS.include?(provider) },
+#               is: -> provider { PROVIDERS.include?(provider) },
 #               message: (lambda do |_input_key, _check_name, value|
 #                 "The specified provider \"#{value}\" was not found."
 #               end)
@@ -59,7 +59,7 @@ module ServiceActor::Conditionable
 
     def define_check_with(check, input_key:, check_name:, value:)
       if check.is_a?(Hash) # advanced mode
-        check, message = check.values_at(:state, :message)
+        check, message = check.values_at(:is, :message)
       else
         message =
           "Input #{input_key} must #{check_name} but was #{value.inspect}"

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -58,7 +58,7 @@ module ServiceActor::Core
   private
 
   # Raises an error depending on the mode
-  def raise_error_with(message, arguments = {})
+  def raise_error_with(message, **arguments)
     message = message.call(**arguments) if message.is_a?(Proc)
 
     raise ServiceActor::ArgumentError, message

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -54,4 +54,10 @@ module ServiceActor::Core
   def fail!(**arguments)
     result.fail!(**arguments)
   end
+
+  def raise_error_with(message, **arguments)
+    raise ServiceActor::ArgumentError, message unless message.is_a?(Proc)
+
+    raise ServiceActor::ArgumentError, message.call(*arguments.values)
+  end
 end

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -59,8 +59,8 @@ module ServiceActor::Core
 
   # Raises an error depending on the mode
   def raise_error_with(message, **arguments)
-    raise ServiceActor::ArgumentError, message unless message.is_a?(Proc)
+    message = message.call(*arguments.values) unless message.is_a?(Proc)
 
-    raise ServiceActor::ArgumentError, message.call(*arguments.values)
+    raise ServiceActor::ArgumentError, message
   end
 end

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -57,6 +57,7 @@ module ServiceActor::Core
 
   private
 
+  # Raises an error depending on the mode
   def raise_error_with(message, **arguments)
     raise ServiceActor::ArgumentError, message unless message.is_a?(Proc)
 

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -59,7 +59,7 @@ module ServiceActor::Core
 
   # Raises an error depending on the mode
   def raise_error_with(message, **arguments)
-    message = message.call(*arguments.values) unless message.is_a?(Proc)
+    message = message.call(*arguments.values) if message.is_a?(Proc)
 
     raise ServiceActor::ArgumentError, message
   end

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -58,8 +58,8 @@ module ServiceActor::Core
   private
 
   # Raises an error depending on the mode
-  def raise_error_with(message, **arguments)
-    message = message.call(*arguments.values) if message.is_a?(Proc)
+  def raise_error_with(message, arguments = {})
+    message = message.call(**arguments) if message.is_a?(Proc)
 
     raise ServiceActor::ArgumentError, message
   end

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -55,6 +55,8 @@ module ServiceActor::Core
     result.fail!(**arguments)
   end
 
+  private
+
   def raise_error_with(message, **arguments)
     raise ServiceActor::ArgumentError, message unless message.is_a?(Proc)
 

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -20,7 +20,7 @@
 #     input :multiplier,
 #           default: {
 #             is: -> { rand(1..10) },
-#             message: (lambda do |input_key:, service_name:|
+#             message: (lambda do |input_key:, actor:|
 #               "Input `#{input_key}` is required"
 #             end)
 #           }
@@ -62,7 +62,7 @@ module ServiceActor::Defaultable
       default, message = content.values_at(:is, :message)
 
       unless default
-        raise_error_with(message, input_key: key, service_name: self.class)
+        raise_error_with(message, input_key: key, actor: self.class)
       end
 
       default = default.call if default.is_a?(Proc)

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -38,8 +38,7 @@ module ServiceActor::Defaultable
         next if result.key?(key)
 
         unless input.key?(:default)
-          raise ServiceActor::ArgumentError,
-                "Input #{key} on #{self.class} is missing"
+          raise_error_with("Input #{key} on #{self.class} is missing")
         end
 
         default = input[:default]
@@ -67,7 +66,7 @@ module ServiceActor::Defaultable
       default, message = content.values_at(:value, :message)
 
       unless default
-        raise ServiceActor::ArgumentError, message.call(key, self.class)
+        raise_error_with(message, input_key: key, service_name: self.class)
       end
 
       default = default.call if default.is_a?(Proc)

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -20,7 +20,7 @@
 #     input :multiplier,
 #           default: {
 #             is: -> { rand(1..10) },
-#             message: (lambda do |input_key, _service_name|
+#             message: (lambda do |input_key:, _service_name:|
 #               "Input `#{input_key}` is required"
 #             end)
 #           }

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -48,8 +48,6 @@ module ServiceActor::Defaultable
         else
           default_for_normal_mode_with(result, key, default)
         end
-
-        next
       end
 
       super

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -14,9 +14,7 @@
 #     input :counter,
 #           default: {
 #             is: 1,
-#             message: (lambda do |input_key, _service_name|
-#               "Input `#{input_key}` is required"
-#             end)
+#             message: "Counter is required"
 #           }
 #
 #     input :multiplier,

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -36,7 +36,7 @@ module ServiceActor::Defaultable
         next if result.key?(key)
 
         unless input.key?(:default)
-          raise_error_with("Input #{key} on #{self.class} is missing")
+          raise_error_with("The #{key} input on #{self.class} is missing")
         end
 
         default = input[:default]

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -13,7 +13,7 @@
 #   class MultiplyThing < Actor
 #     input :counter,
 #           default: {
-#             value: 1,
+#             is: 1,
 #             message: (lambda do |input_key, _service_name|
 #               "Input `#{input_key}` is required"
 #             end)
@@ -21,12 +21,12 @@
 
 #     input :multiplier,
 #           default: {
-#             value: -> { rand(1..10) },
+#             is: -> { rand(1..10) },
 #             message: (lambda do |input_key, _service_name|
 #               "Input `#{input_key}` is required"
 #             end)
 #           }
-# end
+#   end
 module ServiceActor::Defaultable
   def self.included(base)
     base.prepend(PrependedMethods)
@@ -63,7 +63,7 @@ module ServiceActor::Defaultable
     end
 
     def default_for_advanced_mode_with(result, key, content)
-      default, message = content.values_at(:value, :message)
+      default, message = content.values_at(:is, :message)
 
       unless default
         raise_error_with(message, input_key: key, service_name: self.class)

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -21,7 +21,7 @@
 #           default: {
 #             is: -> { rand(1..10) },
 #             message: (lambda do |input_key:, actor:|
-#               "Input `#{input_key}` is required"
+#               "Input \"#{input_key}\" is required"
 #             end)
 #           }
 #   end

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -36,7 +36,9 @@ module ServiceActor::Defaultable
         next if result.key?(key)
 
         unless input.key?(:default)
-          raise_error_with("The #{key} input on #{self.class} is missing")
+          raise_error_with(
+            "The \"#{key}\" input on \"#{self.class}\" is missing",
+          )
         end
 
         default = input[:default]

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -20,7 +20,7 @@
 #     input :multiplier,
 #           default: {
 #             is: -> { rand(1..10) },
-#             message: (lambda do |input_key:, _service_name:|
+#             message: (lambda do |input_key:, service_name:|
 #               "Input `#{input_key}` is required"
 #             end)
 #           }

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -18,7 +18,7 @@
 #               "Input `#{input_key}` is required"
 #             end)
 #           }
-
+#
 #     input :multiplier,
 #           default: {
 #             is: -> { rand(1..10) },

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -17,7 +17,7 @@
 #               "The value `#{input_key}` cannot be empty"
 #             end)
 #           }
-
+#
 #     output :user,
 #             allow_nil: {
 #               is: false,

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -86,18 +86,5 @@ module ServiceActor::NilCheckable
 
       !options[:type]
     end
-
-    # def allow_nil?(options)
-    #   return options[:allow_nil] if options.key?(:allow_nil)
-    #   return true if options.key?(:default) && options[:default].nil?
-
-    #   !options[:type]
-    # end
-
-    # def allow_nil_message?(options)
-    #   return !!options[:allow_nil_message] if options.key?(:allow_nil_message)
-
-    #   false
-    # end
   end
 end

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -13,7 +13,7 @@
 #     input :name,
 #           allow_nil: {
 #             is: false,
-#             message: (lambda do |_origin, _input_key, _service_name|
+#             message: (lambda do |_origin, input_key, _service_name|
 #               "The value `#{input_key}` cannot be empty"
 #             end)
 #           }
@@ -23,7 +23,7 @@
 #     output :user,
 #             allow_nil: {
 #               is: false,
-#               message: (lambda do |_origin, _input_key, _service_name|
+#               message: (lambda do |_origin, input_key, _service_name|
 #                 "The value `#{input_key}` cannot be empty"
 #               end)
 #             }

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -65,7 +65,7 @@ module ServiceActor::NilCheckable
     end
 
     def allow_nil_message?(options)
-      return options[:allow_nil_message] if options.key?(:allow_nil_message)
+      return !!options[:allow_nil_message] if options.key?(:allow_nil_message)
 
       false
     end

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -47,13 +47,12 @@ module ServiceActor::NilCheckable
 
         message = options[:allow_nil_message] if allow_nil_message?(options)
 
-        error_text = if message.is_a?(Proc)
-                       message.call(origin, key, self.class)
-                     else
-                       message
-                     end
-
-        raise ServiceActor::ArgumentError, error_text
+        raise_error_with(
+          message,
+          origin: origin,
+          input_key: key,
+          service_name: self.class,
+        )
       end
     end
 

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -72,16 +72,11 @@ module ServiceActor::NilCheckable
     end
 
     def define_allow_nil_from(allow_nil)
-      message = DEFAULT_MESSAGE
-
-      if allow_nil.is_a?(Hash) # advanced mode
-        allow_nil, message = allow_nil.values_at(:is, :message)
+      if allow_nil.is_a?(Hash)
+        allow_nil.values_at(:is, :message)
+      else
+        [allow_nil, DEFAULT_MESSAGE]
       end
-
-      [
-        allow_nil,
-        message
-      ]
     end
 
     def allow_nil?(allow_nil, options)

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -13,7 +13,7 @@
 #     input :name,
 #           allow_nil: {
 #             is: false,
-#             message: (lambda do |origin:, input_key:, service_name:|
+#             message: (lambda do |origin:, input_key:, actor:|
 #               "The value `#{input_key}` cannot be empty"
 #             end)
 #           }
@@ -23,7 +23,7 @@
 #     output :user,
 #             allow_nil: {
 #               is: false,
-#               message: (lambda do |origin:, input_key:, service_name:|
+#               message: (lambda do |origin:, input_key:, actor:|
 #                 "The value `#{input_key}` cannot be empty"
 #               end)
 #             }
@@ -34,8 +34,8 @@ module ServiceActor::NilCheckable
   end
 
   module PrependedMethods
-    DEFAULT_MESSAGE = lambda do |origin:, input_key:, service_name:|
-      "The #{origin} \"#{input_key}\" on #{service_name} does not allow " \
+    DEFAULT_MESSAGE = lambda do |origin:, input_key:, actor:|
+      "The #{origin} \"#{input_key}\" on #{actor} does not allow " \
       "nil values"
     end
 
@@ -65,7 +65,7 @@ module ServiceActor::NilCheckable
           message,
           origin: origin,
           input_key: key,
-          service_name: self.class,
+          actor: self.class,
         )
       end
     end

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -13,7 +13,7 @@
 #     input :name,
 #           allow_nil: {
 #             is: false,
-#             message: (lambda do |_origin, input_key, _service_name|
+#             message: (lambda do |_origin:, input_key:, _service_name:|
 #               "The value `#{input_key}` cannot be empty"
 #             end)
 #           }
@@ -23,7 +23,7 @@
 #     output :user,
 #             allow_nil: {
 #               is: false,
-#               message: (lambda do |_origin, input_key, _service_name|
+#               message: (lambda do |_origin:, input_key:, _service_name:|
 #                 "The value `#{input_key}` cannot be empty"
 #               end)
 #             }
@@ -34,7 +34,7 @@ module ServiceActor::NilCheckable
   end
 
   module PrependedMethods
-    DEFAULT_MESSAGE = lambda do |origin, input_key, service_name|
+    DEFAULT_MESSAGE = lambda do |origin:, input_key:, service_name:|
       "The #{origin} \"#{input_key}\" on #{service_name} does not allow " \
       "nil values"
     end

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -23,7 +23,7 @@
 #     output :user,
 #             allow_nil: {
 #               is: false,
-#               message: (lambda do |_origin:, input_key:, _service_name:|
+#               message: (lambda do |origin:, input_key:, service_name:|
 #                 "The value `#{input_key}` cannot be empty"
 #               end)
 #             }

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -13,7 +13,7 @@
 #     input :name,
 #           allow_nil: {
 #             is: false,
-#             message: (lambda do |_origin:, input_key:, _service_name:|
+#             message: (lambda do |origin:, input_key:, service_name:|
 #               "The value `#{input_key}` cannot be empty"
 #             end)
 #           }

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -35,7 +35,7 @@ module ServiceActor::NilCheckable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do |origin:, input_key:, actor:|
-      "The \"#{input_key}\" #{origin} on #{actor} does not allow " \
+      "The \"#{input_key}\" #{origin} on \"#{actor}\" does not allow " \
       "nil values"
     end
 

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -14,7 +14,7 @@
 #           allow_nil: {
 #             is: false,
 #             message: (lambda do |origin:, input_key:, actor:|
-#               "The value `#{input_key}` cannot be empty"
+#               "The value \"#{input_key}\" cannot be empty"
 #             end)
 #           }
 #
@@ -24,7 +24,7 @@
 #             allow_nil: {
 #               is: false,
 #               message: (lambda do |origin:, input_key:, actor:|
-#                 "The value `#{input_key}` cannot be empty"
+#                 "The value \"#{input_key}\" cannot be empty"
 #               end)
 #             }
 #   end

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -57,17 +57,16 @@ module ServiceActor::NilCheckable
 
         next unless value.nil?
 
-        base_arguments = {
-          origin: origin,
-          input_key: key,
-          service_name: self.class
-        }
-
         allow_nil, message = define_allow_nil_from(options[:allow_nil])
 
         next if allow_nil?(allow_nil, options)
 
-        raise_error_with(message, **base_arguments)
+        raise_error_with(
+          message,
+          origin: origin,
+          input_key: key,
+          service_name: self.class,
+        )
       end
     end
 

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -35,7 +35,7 @@ module ServiceActor::NilCheckable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do |origin:, input_key:, actor:|
-      "The #{origin} \"#{input_key}\" on #{actor} does not allow " \
+      "The \"#{input_key}\" #{origin} on #{actor} does not allow " \
       "nil values"
     end
 

--- a/lib/service_actor/nil_checkable.rb
+++ b/lib/service_actor/nil_checkable.rb
@@ -18,6 +18,8 @@
 #             end)
 #           }
 #
+#     input :phone, allow_nil: { is: false, message: "Phone must be present" }
+#
 #     output :user,
 #             allow_nil: {
 #               is: false,

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -18,7 +18,7 @@
 #     input :bonus_applied,
 #           type: {
 #             is: [TrueClass, FalseClass],
-#             message: (lambda do |kind:, input_key:, actor:, expected_type:, given_type:| # rubocop:disable Layout/LineLength
+#             message: (lambda do |origin:, input_key:, actor:, expected_type:, given_type:| # rubocop:disable Layout/LineLength
 #               "Wrong type `#{given_type}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type}`"
 #             end)
@@ -31,25 +31,25 @@ module ServiceActor::TypeCheckable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do
-      |kind:, input_key:, actor:, expected_type:, given_type:|
+      |origin:, input_key:, actor:, expected_type:, given_type:|
 
-      "#{kind} #{input_key} on #{actor} must be of type " \
+      "The #{input_key} #{origin} on #{actor} must be of type " \
       "#{expected_type} but was #{given_type}"
     end
 
     private_constant :DEFAULT_MESSAGE
 
     def _call
-      check_type_definitions(self.class.inputs, kind: "Input")
+      check_type_definitions(self.class.inputs, origin: "input")
 
       super
 
-      check_type_definitions(self.class.outputs, kind: "Output")
+      check_type_definitions(self.class.outputs, origin: "output")
     end
 
     private
 
-    def check_type_definitions(definitions, kind:) # rubocop:disable Metrics/MethodLength
+    def check_type_definitions(definitions, origin:) # rubocop:disable Metrics/MethodLength
       definitions.each do |key, options|
         type_definition = options[:type] || next
         value = result[key] || next
@@ -60,7 +60,7 @@ module ServiceActor::TypeCheckable
 
         raise_error_with(
           message,
-          kind: kind,
+          origin: origin,
           input_key: key,
           actor: self.class,
           expected_type: types.join(", "),

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -12,6 +12,9 @@
 #   end
 #
 #   class ReduceOrderAmount < Actor
+#     input :order, type: { is: Order, message: "Order is required" }
+#     input :amount, type: { is: Integer, message: "Incorrect amount" }
+#
 #     input :bonus_applied,
 #           type: {
 #             is: [TrueClass, FalseClass],

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -18,7 +18,7 @@
 #     input :bonus_applied,
 #           type: {
 #             is: [TrueClass, FalseClass],
-#             message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names| # rubocop:disable Layout/LineLength
+#             message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name| # rubocop:disable Layout/LineLength
 #               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type_names}`"
 #             end)
@@ -31,7 +31,7 @@ module ServiceActor::TypeCheckable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do
-      |kind, input_key, service_name, actual_type_name, expected_type_names|
+      |kind, input_key, service_name, expected_type_names, actual_type_name|
 
       "#{kind} #{input_key} on #{service_name} must be of type " \
       "#{expected_type_names} but was #{actual_type_name}"
@@ -54,21 +54,17 @@ module ServiceActor::TypeCheckable
         type_definition = options[:type] || next
         value = result[key] || next
 
-        base_arguments = {
-          kind: kind,
-          input_key: key,
-          service_name: self.class,
-          actual_type_name: value.class
-        }
-
         types, message = define_types_with(type_definition)
 
         next if types.any? { |type| value.is_a?(type) }
 
         raise_error_with(
           message,
-          **base_arguments,
+          kind: kind,
+          input_key: key,
+          service_name: self.class,
           expected_type_names: types.join(", "),
+          actual_type_name: value.class,
         )
       end
     end

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -10,15 +10,12 @@
 #     input :amount, type: [Integer, Float]
 #     input :bonus_applied, type: [TrueClass, FalseClass]
 #   end
-
+#
 #   class ReduceOrderAmount < Actor
 #     input :bonus_applied,
 #           type: {
 #             class_name: [TrueClass, FalseClass],
-#             message: (lambda do
-#               |_kind, input_key, _service_name,
-#                actual_type_name, expected_type_names|
-
+#             message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names| # rubocop:disable Layout/LineLength
 #               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type_names}`"
 #             end)

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -15,7 +15,7 @@
 #     input :bonus_applied,
 #           type: {
 #             class_name: [TrueClass, FalseClass],
-#             message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
+#             message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
 #               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type_names}`"
 #             end)
@@ -42,24 +42,22 @@ module ServiceActor::TypeCheckable
         type_definition = options[:type] || next
         value = result[key] || next
 
-        # FIXME: The `prototype_3_with` method needs to be renamed.
-        types, message = prototype_3_with(
-          type_definition,
+        base_arguments = {
           kind: kind,
           input_key: key,
           service_name: self.class,
-          actual_type_name: value.class,
-        )
+          actual_type_name: value.class
+        }
+
+        # FIXME: The `prototype_3_with` method needs to be renamed.
+        types, message = prototype_3_with(type_definition, **base_arguments)
 
         next if types.any? { |type| value.is_a?(type) }
 
         raise_error_with(
           message,
-          kind: kind,
-          input_key: key,
-          service_name: self.class,
+          **base_arguments,
           expected_type_names: types.join(", "),
-          actual_type_name: value.class,
         )
       end
     end

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -74,19 +74,16 @@ module ServiceActor::TypeCheckable
     end
 
     def define_types_with(type_definition)
-      message = DEFAULT_MESSAGE
-
-      if type_definition.is_a?(Hash) # advanced mode
+      if type_definition.is_a?(Hash)
         type_definition, message =
           type_definition.values_at(:is, :message)
+      else
+        message = DEFAULT_MESSAGE
       end
 
       types = types_for_definition(type_definition)
 
-      [
-        types,
-        message
-      ]
+      [types, message]
     end
 
     def types_for_definition(type_definition)

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -43,25 +43,24 @@ module ServiceActor::TypeCheckable
         type_definition = options[:type] || next
         value = result[key] || next
 
+        message = "#{kind} #{key} on #{self.class} must be of type " \
+                  "#{types.join(', ')} but was #{value.class}"
+
         if type_definition.is_a?(Hash) # advanced mode
           type_definition, message =
             type_definition.values_at(:class_name, :message)
-          types = types_for_definition(type_definition)
-        else
-          types = types_for_definition(type_definition)
-          message = "#{kind} #{key} on #{self.class} must be of type " \
-                    "#{types.join(', ')} but was #{value.class}"
         end
+
+        types = types_for_definition(type_definition)
 
         next if types.any? { |type| value.is_a?(type) }
 
-        error_text = if message.is_a?(Proc)
-                       message.call(
-                         kind, key, self.class, types.join(", "), value.class
-                       )
-                     else
-                       message
-                     end
+        error_text =
+          if message.is_a?(Proc)
+            message.call(kind, key, self.class, types.join(", "), value.class)
+          else
+            message
+          end
 
         raise ServiceActor::ArgumentError, error_text
       end

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -33,8 +33,8 @@ module ServiceActor::TypeCheckable
     DEFAULT_MESSAGE = lambda do
       |origin:, input_key:, actor:, expected_type:, given_type:|
 
-      "The #{input_key} #{origin} on #{actor} must be of type " \
-      "#{expected_type} but was #{given_type}"
+      "The \"#{input_key}\" #{origin} on \"#{actor}\" must be of type " \
+      "\"#{expected_type}\" but was \"#{given_type}\""
     end
 
     private_constant :DEFAULT_MESSAGE

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -64,6 +64,7 @@ module ServiceActor::TypeCheckable
       end
     end
 
+    # FIXME: The `prototype_3_with` method needs to be renamed.
     def prototype_3_with( # rubocop:disable Metrics/MethodLength
       type_definition,
       kind:,

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -37,8 +37,7 @@ module ServiceActor::TypeCheckable
 
     private
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    def check_type_definitions(definitions, kind:)
+    def check_type_definitions(definitions, kind:) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       definitions.each do |key, options|
         type_definition = options[:type] || next
         value = result[key] || next
@@ -55,17 +54,16 @@ module ServiceActor::TypeCheckable
 
         next if types.any? { |type| value.is_a?(type) }
 
-        error_text =
-          if message.is_a?(Proc)
-            message.call(kind, key, self.class, types.join(", "), value.class)
-          else
-            message
-          end
-
-        raise ServiceActor::ArgumentError, error_text
+        raise_error_with(
+          message,
+          kind: kind,
+          input_key: key,
+          service_name: self.class,
+          expected_type_names: types.join(", "),
+          actual_type_name: value.class,
+        )
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def types_for_definition(type_definition)
       Array(type_definition).map do |name|

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -43,15 +43,15 @@ module ServiceActor::TypeCheckable
         type_definition = options[:type] || next
         value = result[key] || next
 
-        message = "#{kind} #{key} on #{self.class} must be of type " \
-                  "#{types.join(', ')} but was #{value.class}"
-
         if type_definition.is_a?(Hash) # advanced mode
           type_definition, message =
             type_definition.values_at(:class_name, :message)
+          types = types_for_definition(type_definition)
+        else
+          types = types_for_definition(type_definition)
+          message = "#{kind} #{key} on #{self.class} must be of type " \
+                    "#{types.join(', ')} but was #{value.class}"
         end
-
-        types = types_for_definition(type_definition)
 
         next if types.any? { |type| value.is_a?(type) }
 

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -49,8 +49,7 @@ module ServiceActor::TypeCheckable
           actual_type_name: value.class
         }
 
-        # FIXME: The `prototype_3_with` method needs to be renamed.
-        types, message = prototype_3_with(type_definition, **base_arguments)
+        types, message = define_types_with(type_definition, **base_arguments)
 
         next if types.any? { |type| value.is_a?(type) }
 
@@ -62,8 +61,7 @@ module ServiceActor::TypeCheckable
       end
     end
 
-    # FIXME: The `prototype_3_with` method needs to be renamed.
-    def prototype_3_with( # rubocop:disable Metrics/MethodLength
+    def define_types_with( # rubocop:disable Metrics/MethodLength
       type_definition,
       kind:,
       input_key:,

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -18,9 +18,9 @@
 #     input :bonus_applied,
 #           type: {
 #             is: [TrueClass, FalseClass],
-#             message: (lambda do |kind:, input_key:, service_name:, expected_type_names:, actual_type_name:| # rubocop:disable Layout/LineLength
-#               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
-#               "Expected: `#{expected_type_names}`"
+#             message: (lambda do |kind:, input_key:, service_name:, expected_type:, given_type:| # rubocop:disable Layout/LineLength
+#               "Wrong type `#{given_type}` for `#{input_key}`. " \
+#               "Expected: `#{expected_type}`"
 #             end)
 #           }
 #   end
@@ -31,10 +31,10 @@ module ServiceActor::TypeCheckable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do
-      |kind:, input_key:, service_name:, expected_type_names:, actual_type_name:| # rubocop:disable Layout/LineLength
+      |kind:, input_key:, service_name:, expected_type:, given_type:|
 
       "#{kind} #{input_key} on #{service_name} must be of type " \
-      "#{expected_type_names} but was #{actual_type_name}"
+      "#{expected_type} but was #{given_type}"
     end
 
     private_constant :DEFAULT_MESSAGE
@@ -63,8 +63,8 @@ module ServiceActor::TypeCheckable
           kind: kind,
           input_key: key,
           service_name: self.class,
-          expected_type_names: types.join(", "),
-          actual_type_name: value.class,
+          expected_type: types.join(", "),
+          given_type: value.class,
         )
       end
     end

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -18,7 +18,7 @@
 #     input :bonus_applied,
 #           type: {
 #             is: [TrueClass, FalseClass],
-#             message: (lambda do |kind:, input_key:, service_name:, expected_type:, given_type:| # rubocop:disable Layout/LineLength
+#             message: (lambda do |kind:, input_key:, actor:, expected_type:, given_type:| # rubocop:disable Layout/LineLength
 #               "Wrong type `#{given_type}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type}`"
 #             end)
@@ -31,9 +31,9 @@ module ServiceActor::TypeCheckable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do
-      |kind:, input_key:, service_name:, expected_type:, given_type:|
+      |kind:, input_key:, actor:, expected_type:, given_type:|
 
-      "#{kind} #{input_key} on #{service_name} must be of type " \
+      "#{kind} #{input_key} on #{actor} must be of type " \
       "#{expected_type} but was #{given_type}"
     end
 
@@ -62,7 +62,7 @@ module ServiceActor::TypeCheckable
           message,
           kind: kind,
           input_key: key,
-          service_name: self.class,
+          actor: self.class,
           expected_type: types.join(", "),
           given_type: value.class,
         )

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -18,7 +18,7 @@
 #     input :bonus_applied,
 #           type: {
 #             is: [TrueClass, FalseClass],
-#             message: (lambda do |_kind:, input_key:, _service_name:, expected_type_names:, actual_type_name:| # rubocop:disable Layout/LineLength
+#             message: (lambda do |kind:, input_key:, service_name:, expected_type_names:, actual_type_name:| # rubocop:disable Layout/LineLength
 #               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type_names}`"
 #             end)

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -19,8 +19,8 @@
 #           type: {
 #             is: [TrueClass, FalseClass],
 #             message: (lambda do |origin:, input_key:, actor:, expected_type:, given_type:| # rubocop:disable Layout/LineLength
-#               "Wrong type `#{given_type}` for `#{input_key}`. " \
-#               "Expected: `#{expected_type}`"
+#               "Wrong type \"#{given_type}\" for \"#{input_key}\". " \
+#               "Expected: \"#{expected_type}\""
 #             end)
 #           }
 #   end

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -14,7 +14,7 @@
 #   class ReduceOrderAmount < Actor
 #     input :bonus_applied,
 #           type: {
-#             class_name: [TrueClass, FalseClass],
+#             is: [TrueClass, FalseClass],
 #             message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names| # rubocop:disable Layout/LineLength
 #               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type_names}`"
@@ -70,7 +70,7 @@ module ServiceActor::TypeCheckable
     ) # do
       if type_definition.is_a?(Hash) # advanced mode
         type_definition, message =
-          type_definition.values_at(:class_name, :message)
+          type_definition.values_at(:is, :message)
         types = types_for_definition(type_definition)
       else
         types = types_for_definition(type_definition)

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -10,12 +10,15 @@
 #     input :amount, type: [Integer, Float]
 #     input :bonus_applied, type: [TrueClass, FalseClass]
 #   end
-#
+
 #   class ReduceOrderAmount < Actor
 #     input :bonus_applied,
 #           type: {
 #             class_name: [TrueClass, FalseClass],
-#             message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
+#             message: (lambda do
+#               |_kind, input_key, _service_name,
+#                actual_type_name, expected_type_names|
+
 #               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type_names}`"
 #             end)

--- a/lib/service_actor/type_checkable.rb
+++ b/lib/service_actor/type_checkable.rb
@@ -18,7 +18,7 @@
 #     input :bonus_applied,
 #           type: {
 #             is: [TrueClass, FalseClass],
-#             message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name| # rubocop:disable Layout/LineLength
+#             message: (lambda do |_kind:, input_key:, _service_name:, expected_type_names:, actual_type_name:| # rubocop:disable Layout/LineLength
 #               "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
 #               "Expected: `#{expected_type_names}`"
 #             end)
@@ -31,7 +31,7 @@ module ServiceActor::TypeCheckable
 
   module PrependedMethods
     DEFAULT_MESSAGE = lambda do
-      |kind, input_key, service_name, expected_type_names, actual_type_name|
+      |kind:, input_key:, service_name:, expected_type_names:, actual_type_name:| # rubocop:disable Layout/LineLength
 
       "#{kind} #{input_key} on #{service_name} must be of type " \
       "#{expected_type_names} but was #{actual_type_name}"

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -458,8 +458,9 @@ RSpec.describe Actor do
 
         context "when given an incorrect value" do
           let(:expected_alert) do
-            "Input provider must be included in " \
-              '["MANGOPAY", "PayPal", "Stripe"] but instead was "Paypal"'
+            "The input provider must be included in " \
+              '["MANGOPAY", "PayPal", "Stripe"] on PayWithProviderInclusion ' \
+                'instead of "Paypal"'
           end
 
           it "fails" do
@@ -515,8 +516,9 @@ RSpec.describe Actor do
 
         context "when given an incorrect value" do
           let(:expected_alert) do
-            "Input provider must be included in " \
-              '["MANGOPAY", "PayPal", "Stripe"] but instead was "Paypal"'
+            "The input provider must be included in " \
+              '["MANGOPAY", "PayPal", "Stripe"] on PayWithProvider ' \
+                'instead of "Paypal"'
           end
 
           it "fails" do

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Actor do
       end
 
       context "when advanced mode" do
-        context "when called with the wrong condition" do # rubocop:disable RSpec/NestedGroups
+        context "when called with the wrong condition" do
           it "raises" do
             expected_error = "Failed to apply `be_lowercase`"
 
@@ -350,19 +350,38 @@ RSpec.describe Actor do
     end
 
     context "when disallowing nil on an input" do
-      context "when given the input" do
-        it "succeeds" do
-          expect(DisallowNilOnInput.call(name: "Jim")).to be_a_success
+      context "when normal mode" do
+        context "when given the input" do
+          it "succeeds" do
+            expect(DisallowNilOnInput.call(name: "Jim")).to be_a_success
+          end
+        end
+
+        context "without the input" do
+          it "fails" do
+            expected_error =
+              'The input "name" on DisallowNilOnInput does not allow nil values'
+
+            expect { DisallowNilOnInput.call(name: nil) }
+              .to raise_error(ServiceActor::ArgumentError, expected_error)
+          end
         end
       end
 
-      context "without the input" do
-        it "fails" do
-          expected_error =
-            'The input "name" on DisallowNilOnInput does not allow nil values'
+      context "when advanced mode" do
+        context "when given the input" do
+          it "succeeds" do
+            expect(DisallowNilOnInputAdvanced.call(name: "Jim")).to be_a_success
+          end
+        end
 
-          expect { DisallowNilOnInput.call(name: nil) }
-            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        context "without the input" do
+          it "fails" do
+            expected_error = "The value `name` cannot be empty"
+
+            expect { DisallowNilOnInputAdvanced.call(name: nil) }
+              .to raise_error(ServiceActor::ArgumentError, expected_error)
+          end
         end
       end
     end
@@ -432,14 +451,14 @@ RSpec.describe Actor do
 
     context 'when using "inclusion"' do
       context "when normal mode" do
-        context "when given a correct value" do # rubocop:disable RSpec/NestedGroups
+        context "when given a correct value" do
           it "returns the message" do
             actor = PayWithProvider.call(provider: "PayPal")
             expect(actor.message).to eq("Money transferred to PayPal!")
           end
         end
 
-        context "when given an incorrect value" do # rubocop:disable RSpec/NestedGroups
+        context "when given an incorrect value" do
           let(:expected_alert) do
             "Input provider must be included in " \
               '["MANGOPAY", "PayPal", "Stripe"] but instead was "Paypal"'
@@ -451,7 +470,7 @@ RSpec.describe Actor do
           end
         end
 
-        context "when it has a default" do # rubocop:disable RSpec/NestedGroups
+        context "when it has a default" do
           it "uses it" do
             actor = PayWithProvider.call
             expect(actor.message).to eq("Money transferred to Stripe!")
@@ -460,14 +479,14 @@ RSpec.describe Actor do
       end
 
       context "when advanced mode" do
-        context "when given a correct value" do # rubocop:disable RSpec/NestedGroups
+        context "when given a correct value" do
           it "returns the message" do
             actor = PayWithProviderAdvanced.call(provider: "PayPal")
             expect(actor.message).to eq("Money transferred to PayPal!")
           end
         end
 
-        context "when given an incorrect value" do # rubocop:disable RSpec/NestedGroups
+        context "when given an incorrect value" do
           let(:expected_alert) do
             "Payment system \"Paypal\" is not supported"
           end
@@ -478,14 +497,14 @@ RSpec.describe Actor do
           end
         end
 
-        context "when it has a default" do # rubocop:disable RSpec/NestedGroups
+        context "when it has a default" do
           it "uses it" do
             actor = PayWithProviderAdvanced.call
             expect(actor.message).to eq("Money transferred to Stripe!")
           end
         end
 
-        context "when it has a default but no value" do # rubocop:disable RSpec/NestedGroups
+        context "when it has a default but no value" do
           expected_error = "Input `provider` is required"
 
           it "fails" do

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Actor do
         expect { SetNameToDowncase.call }
           .to raise_error(
             ServiceActor::ArgumentError,
-            "Input name on SetNameToDowncase is missing",
+            "The name input on SetNameToDowncase is missing",
           )
       end
     end
@@ -256,7 +256,7 @@ RSpec.describe Actor do
 
     context "when called with the wrong type of argument" do
       let(:expected_message) do
-        "Input name on SetNameToDowncase must be of type String but was " \
+        "The name input on SetNameToDowncase must be of type String but was " \
           "#{1.class.name}"
       end
 
@@ -268,7 +268,7 @@ RSpec.describe Actor do
 
     context "when a type is defined but the argument is nil" do
       let(:expected_message) do
-        'The input "name" on SetNameToDowncase does not allow nil values'
+        'The "name" input on SetNameToDowncase does not allow nil values'
       end
 
       it "raises" do
@@ -286,7 +286,7 @@ RSpec.describe Actor do
       context "when normal mode" do
         it "does not allow other types" do
           expected_error =
-            "Input value on DoubleWithTypeAsString must be of type Integer, " \
+            "The value input on DoubleWithTypeAsString must be of type Integer, " \
             "Float but was String"
           expect { DoubleWithTypeAsString.call(value: "2.0") }
             .to raise_error(ServiceActor::ArgumentError, expected_error)
@@ -306,7 +306,7 @@ RSpec.describe Actor do
     context "when setting the wrong type of output" do
       context "when normal mode" do
         let(:expected_message) do
-          "Output name on SetWrongTypeOfOutput must be of type String but " \
+          "The name output on SetWrongTypeOfOutput must be of type String but " \
             "was #{1.class.name}"
         end
 
@@ -359,7 +359,7 @@ RSpec.describe Actor do
         context "without the input" do
           it "fails" do
             expected_error =
-              'The input "name" on DisallowNilOnInput does not allow nil values'
+              'The "name" input on DisallowNilOnInput does not allow nil values'
 
             expect { DisallowNilOnInput.call(name: nil) }
               .to raise_error(ServiceActor::ArgumentError, expected_error)
@@ -410,7 +410,7 @@ RSpec.describe Actor do
       context "without the output" do
         it "fails" do
           expected_error =
-            'The output "name" on DisallowNilOnOutput does not allow nil values'
+            'The "name" output on DisallowNilOnOutput does not allow nil values'
 
           expect { DisallowNilOnOutput.call(test_without_output: true) }
             .to raise_error(ServiceActor::ArgumentError, expected_error)
@@ -594,7 +594,7 @@ RSpec.describe Actor do
     context "with an argument error, caught by fail_on" do
       let(:actor) { FailOnArgumentError.result(name: 42) }
       let(:expected_error_message) do
-        "Input name on FailOnArgumentError must be of type String but was " \
+        "The name input on FailOnArgumentError must be of type String but was " \
           "Integer"
       end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -236,7 +236,8 @@ RSpec.describe Actor do
     context "when called with the wrong condition" do
       context "when normal mode" do
         it "raises" do
-          expected_error = 'Input name must be_lowercase but was "42"'
+          expected_error = "The name input on SetNameWithInputCondition " \
+                            "must be_lowercase but was \"42\""
 
           expect { SetNameWithInputCondition.call(name: "42") }
             .to raise_error(ServiceActor::ArgumentError, expected_error)
@@ -458,7 +459,7 @@ RSpec.describe Actor do
 
         context "when given an incorrect value" do
           let(:expected_alert) do
-            "The input provider must be included in " \
+            "The provider input must be included in " \
               '["MANGOPAY", "PayPal", "Stripe"] on PayWithProviderInclusion ' \
                 'instead of "Paypal"'
           end
@@ -516,7 +517,7 @@ RSpec.describe Actor do
 
         context "when given an incorrect value" do
           let(:expected_alert) do
-            "The input provider must be included in " \
+            "The provider input must be included in " \
               '["MANGOPAY", "PayPal", "Stripe"] on PayWithProvider ' \
                 'instead of "Paypal"'
           end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -286,8 +286,8 @@ RSpec.describe Actor do
       context "when normal mode" do
         it "does not allow other types" do
           expected_error =
-            "The value input on DoubleWithTypeAsString must be of type Integer, " \
-            "Float but was String"
+            "The value input on DoubleWithTypeAsString must " \
+            "be of type Integer, Float but was String"
           expect { DoubleWithTypeAsString.call(value: "2.0") }
             .to raise_error(ServiceActor::ArgumentError, expected_error)
         end
@@ -306,8 +306,8 @@ RSpec.describe Actor do
     context "when setting the wrong type of output" do
       context "when normal mode" do
         let(:expected_message) do
-          "The name output on SetWrongTypeOfOutput must be of type String but " \
-            "was #{1.class.name}"
+          "The name output on SetWrongTypeOfOutput must " \
+            "be of type String but was #{1.class.name}"
         end
 
         it "raises" do
@@ -594,8 +594,8 @@ RSpec.describe Actor do
     context "with an argument error, caught by fail_on" do
       let(:actor) { FailOnArgumentError.result(name: 42) }
       let(:expected_error_message) do
-        "The name input on FailOnArgumentError must be of type String but was " \
-          "Integer"
+        "The name input on FailOnArgumentError must " \
+          "be of type String but was Integer"
       end
 
       it { expect(actor).to be_a_failure }

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe Actor do
         expect { SetNameToDowncase.call }
           .to raise_error(
             ServiceActor::ArgumentError,
-            "The name input on SetNameToDowncase is missing",
+            "The \"name\" input on \"SetNameToDowncase\" is missing",
           )
       end
     end
@@ -236,8 +236,9 @@ RSpec.describe Actor do
     context "when called with the wrong condition" do
       context "when normal mode" do
         it "raises" do
-          expected_error = "The name input on SetNameWithInputCondition " \
-                            "must be_lowercase but was \"42\""
+          expected_error =
+            "The \"name\" input on \"SetNameWithInputCondition\" " \
+            "must \"be_lowercase\" but was \"42\""
 
           expect { SetNameWithInputCondition.call(name: "42") }
             .to raise_error(ServiceActor::ArgumentError, expected_error)
@@ -256,8 +257,8 @@ RSpec.describe Actor do
 
     context "when called with the wrong type of argument" do
       let(:expected_message) do
-        "The name input on SetNameToDowncase must be of type String but was " \
-          "#{1.class.name}"
+        "The \"name\" input on \"SetNameToDowncase\" must be of " \
+          "type \"String\" but was \"#{1.class.name}\""
       end
 
       it "raises" do
@@ -268,7 +269,7 @@ RSpec.describe Actor do
 
     context "when a type is defined but the argument is nil" do
       let(:expected_message) do
-        'The "name" input on SetNameToDowncase does not allow nil values'
+        'The "name" input on "SetNameToDowncase" does not allow nil values'
       end
 
       it "raises" do
@@ -286,8 +287,8 @@ RSpec.describe Actor do
       context "when normal mode" do
         it "does not allow other types" do
           expected_error =
-            "The value input on DoubleWithTypeAsString must " \
-            "be of type Integer, Float but was String"
+            "The \"value\" input on \"DoubleWithTypeAsString\" must " \
+            "be of type \"Integer, Float\" but was \"String\""
           expect { DoubleWithTypeAsString.call(value: "2.0") }
             .to raise_error(ServiceActor::ArgumentError, expected_error)
         end
@@ -306,8 +307,8 @@ RSpec.describe Actor do
     context "when setting the wrong type of output" do
       context "when normal mode" do
         let(:expected_message) do
-          "The name output on SetWrongTypeOfOutput must " \
-            "be of type String but was #{1.class.name}"
+          "The \"name\" output on \"SetWrongTypeOfOutput\" must " \
+            "be of type \"String\" but was \"#{1.class.name}\""
         end
 
         it "raises" do
@@ -359,7 +360,8 @@ RSpec.describe Actor do
         context "without the input" do
           it "fails" do
             expected_error =
-              'The "name" input on DisallowNilOnInput does not allow nil values'
+              "The \"name\" input on \"DisallowNilOnInput\" does not " \
+              "allow nil values"
 
             expect { DisallowNilOnInput.call(name: nil) }
               .to raise_error(ServiceActor::ArgumentError, expected_error)
@@ -410,7 +412,8 @@ RSpec.describe Actor do
       context "without the output" do
         it "fails" do
           expected_error =
-            'The "name" output on DisallowNilOnOutput does not allow nil values'
+            "The \"name\" output on \"DisallowNilOnOutput\" " \
+            "does not allow nil values"
 
           expect { DisallowNilOnOutput.call(test_without_output: true) }
             .to raise_error(ServiceActor::ArgumentError, expected_error)
@@ -459,9 +462,9 @@ RSpec.describe Actor do
 
         context "when given an incorrect value" do
           let(:expected_alert) do
-            "The provider input must be included in " \
-              '["MANGOPAY", "PayPal", "Stripe"] on PayWithProviderInclusion ' \
-                'instead of "Paypal"'
+            'The "provider" input must be included in ' \
+            '["MANGOPAY", "PayPal", "Stripe"] on "PayWithProviderInclusion" ' \
+            'instead of "Paypal"'
           end
 
           it "fails" do
@@ -517,9 +520,9 @@ RSpec.describe Actor do
 
         context "when given an incorrect value" do
           let(:expected_alert) do
-            "The provider input must be included in " \
-              '["MANGOPAY", "PayPal", "Stripe"] on PayWithProvider ' \
-                'instead of "Paypal"'
+            'The "provider" input must be included in ' \
+            '["MANGOPAY", "PayPal", "Stripe"] on "PayWithProvider" ' \
+            'instead of "Paypal"'
           end
 
           it "fails" do
@@ -594,8 +597,8 @@ RSpec.describe Actor do
     context "with an argument error, caught by fail_on" do
       let(:actor) { FailOnArgumentError.result(name: 42) }
       let(:expected_error_message) do
-        "The name input on FailOnArgumentError must " \
-          "be of type String but was Integer"
+        "The \"name\" input on \"FailOnArgumentError\" must " \
+          "be of type \"String\" but was \"Integer\""
       end
 
       it { expect(actor).to be_a_failure }

--- a/spec/examples/disallow_nil_on_input_advanced.rb
+++ b/spec/examples/disallow_nil_on_input_advanced.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class DisallowNilOnInputAdvanced < Actor
+  input :name,
+        type: String,
+        allow_nil: false,
+        allow_nil_message: (lambda do |_origin, input_key, _service_name|
+          "The value `#{input_key}` cannot be empty"
+        end)
+
+  def call; end
+end

--- a/spec/examples/disallow_nil_on_input_advanced.rb
+++ b/spec/examples/disallow_nil_on_input_advanced.rb
@@ -3,10 +3,12 @@
 class DisallowNilOnInputAdvanced < Actor
   input :name,
         type: String,
-        allow_nil: false,
-        allow_nil_message: (lambda do |_origin, input_key, _service_name|
-          "The value `#{input_key}` cannot be empty"
-        end)
+        allow_nil: {
+          is: false,
+          message: (lambda do |_origin, input_key, _service_name|
+            "The value `#{input_key}` cannot be empty"
+          end)
+        }
 
   def call; end
 end

--- a/spec/examples/disallow_nil_on_input_advanced.rb
+++ b/spec/examples/disallow_nil_on_input_advanced.rb
@@ -5,7 +5,7 @@ class DisallowNilOnInputAdvanced < Actor
         type: String,
         allow_nil: {
           is: false,
-          message: (lambda do |_origin, input_key, _service_name|
+          message: (lambda do |input_key:, **|
             "The value `#{input_key}` cannot be empty"
           end)
         }

--- a/spec/examples/double_with_type_as_string_advanced.rb
+++ b/spec/examples/double_with_type_as_string_advanced.rb
@@ -5,7 +5,7 @@ class DoubleWithTypeAsStringAdvanced < Actor
   input :value,
         type: {
           class_name: [Integer, "Float"],
-          message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
+          message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
             "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
             "Expected: `#{expected_type_names}`"
           end)

--- a/spec/examples/double_with_type_as_string_advanced.rb
+++ b/spec/examples/double_with_type_as_string_advanced.rb
@@ -4,7 +4,7 @@ class DoubleWithTypeAsStringAdvanced < Actor
   # rubocop:disable Layout/LineLength
   input :value,
         type: {
-          class_name: [Integer, "Float"],
+          is: [Integer, "Float"],
           message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
             "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
             "Expected: `#{expected_type_names}`"

--- a/spec/examples/double_with_type_as_string_advanced.rb
+++ b/spec/examples/double_with_type_as_string_advanced.rb
@@ -5,7 +5,7 @@ class DoubleWithTypeAsStringAdvanced < Actor
   input :value,
         type: {
           is: [Integer, "Float"],
-          message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
+          message: (lambda do |input_key:, expected_type_names:, actual_type_name:, **|
             "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
             "Expected: `#{expected_type_names}`"
           end)

--- a/spec/examples/double_with_type_as_string_advanced.rb
+++ b/spec/examples/double_with_type_as_string_advanced.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
 class DoubleWithTypeAsStringAdvanced < Actor
-  # rubocop:disable Layout/LineLength
   input :value,
         type: {
           is: [Integer, "Float"],
-          message: (lambda do |input_key:, expected_type_names:, actual_type_name:, **|
-            "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
-            "Expected: `#{expected_type_names}`"
+          message: (lambda do |input_key:, expected_type:, given_type:, **|
+            "Wrong type `#{given_type}` for `#{input_key}`. " \
+            "Expected: `#{expected_type}`"
           end)
         }
-  # rubocop:enable Layout/LineLength
-
   output :double
 
   def call

--- a/spec/examples/double_with_type_as_string_advanced.rb
+++ b/spec/examples/double_with_type_as_string_advanced.rb
@@ -5,7 +5,7 @@ class DoubleWithTypeAsStringAdvanced < Actor
   input :value,
         type: {
           is: [Integer, "Float"],
-          message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
+          message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
             "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
             "Expected: `#{expected_type_names}`"
           end)

--- a/spec/examples/pay_with_provider.rb
+++ b/spec/examples/pay_with_provider.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PayWithProvider < Actor
-  input :provider, inclusion: %w[MANGOPAY PayPal Stripe], default: "Stripe"
+  input :provider, in: %w[MANGOPAY PayPal Stripe], default: "Stripe"
   output :message, type: String
 
   def call

--- a/spec/examples/pay_with_provider_advanced.rb
+++ b/spec/examples/pay_with_provider_advanced.rb
@@ -4,7 +4,7 @@ class PayWithProviderAdvanced < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, value, _inclusion_in|
+          message: (lambda do |_input_key, _inclusion_in, value|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/pay_with_provider_advanced.rb
+++ b/spec/examples/pay_with_provider_advanced.rb
@@ -4,7 +4,7 @@ class PayWithProviderAdvanced < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, _in, value|
+          message: (lambda do |_input_key, value, _inclusion_in|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/pay_with_provider_advanced.rb
+++ b/spec/examples/pay_with_provider_advanced.rb
@@ -4,7 +4,7 @@ class PayWithProviderAdvanced < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, _inclusion_in, value|
+          message: (lambda do |value:, **|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
+++ b/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
@@ -4,7 +4,7 @@ class PayWithProviderAdvancedButNoDefaultValue < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, _in, value|
+          message: (lambda do |_input_key, value, _inclusion_in|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
+++ b/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
@@ -4,13 +4,13 @@ class PayWithProviderAdvancedButNoDefaultValue < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, _inclusion_in, value|
+          message: (lambda do |_input_key:, _inclusion_in:, value:|
             "Payment system \"#{value}\" is not supported"
           end)
         },
         default: {
           # value: "Stripe",
-          message: (lambda do |input_key, _service_name|
+          message: (lambda do |input_key:, _service_name:|
             "Input `#{input_key}` is required"
           end)
         }

--- a/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
+++ b/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
@@ -4,7 +4,7 @@ class PayWithProviderAdvancedButNoDefaultValue < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key:, _inclusion_in:, value:|
+          message: (lambda do |value:, **|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
+++ b/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
@@ -4,7 +4,7 @@ class PayWithProviderAdvancedButNoDefaultValue < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, value, _inclusion_in|
+          message: (lambda do |_input_key, _inclusion_in, value|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
+++ b/spec/examples/pay_with_provider_advanced_but_no_default_value.rb
@@ -10,7 +10,7 @@ class PayWithProviderAdvancedButNoDefaultValue < Actor
         },
         default: {
           # value: "Stripe",
-          message: (lambda do |input_key:, _service_name:|
+          message: (lambda do |input_key:, **|
             "Input `#{input_key}` is required"
           end)
         }

--- a/spec/examples/pay_with_provider_inclusion_advanced.rb
+++ b/spec/examples/pay_with_provider_inclusion_advanced.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class PayWithProviderInclusionAdvanced < Actor
+  input :provider,
+        inclusion: {
+          in: %w[MANGOPAY PayPal Stripe],
+          message: (lambda do |_input_key, value, _inclusion_in|
+            "Payment system \"#{value}\" is not supported"
+          end)
+        },
+        default: "Stripe"
+
+  output :message, type: String
+
+  def call
+    self.message = "Money transferred to #{provider}!"
+  end
+end

--- a/spec/examples/pay_with_provider_inclusion_advanced.rb
+++ b/spec/examples/pay_with_provider_inclusion_advanced.rb
@@ -4,7 +4,7 @@ class PayWithProviderInclusionAdvanced < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, value, _inclusion_in|
+          message: (lambda do |_input_key, _inclusion_in, value|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/pay_with_provider_inclusion_advanced.rb
+++ b/spec/examples/pay_with_provider_inclusion_advanced.rb
@@ -4,7 +4,7 @@ class PayWithProviderInclusionAdvanced < Actor
   input :provider,
         inclusion: {
           in: %w[MANGOPAY PayPal Stripe],
-          message: (lambda do |_input_key, _inclusion_in, value|
+          message: (lambda do |value:, **|
             "Payment system \"#{value}\" is not supported"
           end)
         },

--- a/spec/examples/set_name_with_input_condition_advanced.rb
+++ b/spec/examples/set_name_with_input_condition_advanced.rb
@@ -6,8 +6,8 @@ class SetNameWithInputConditionAdvanced < Actor
         must: {
           be_lowercase: {
             state: -> name { name =~ /\A[a-z]+\z/ },
-            message: (lambda do |_input_key, must_key, _value|
-              "Failed to apply `#{must_key}`"
+            message: (lambda do |_input_key, check_name, _value|
+              "Failed to apply `#{check_name}`"
             end)
           }
         }

--- a/spec/examples/set_name_with_input_condition_advanced.rb
+++ b/spec/examples/set_name_with_input_condition_advanced.rb
@@ -5,7 +5,7 @@ class SetNameWithInputConditionAdvanced < Actor
         type: String,
         must: {
           be_lowercase: {
-            state: -> name { name =~ /\A[a-z]+\z/ },
+            is: -> name { name =~ /\A[a-z]+\z/ },
             message: (lambda do |_input_key, check_name, _value|
               "Failed to apply `#{check_name}`"
             end)

--- a/spec/examples/set_name_with_input_condition_advanced.rb
+++ b/spec/examples/set_name_with_input_condition_advanced.rb
@@ -6,7 +6,7 @@ class SetNameWithInputConditionAdvanced < Actor
         must: {
           be_lowercase: {
             is: -> name { name =~ /\A[a-z]+\z/ },
-            message: (lambda do |_input_key, check_name, _value|
+            message: (lambda do |check_name:, **|
               "Failed to apply `#{check_name}`"
             end)
           }

--- a/spec/examples/set_wrong_type_of_output_advanced.rb
+++ b/spec/examples/set_wrong_type_of_output_advanced.rb
@@ -5,7 +5,7 @@ class SetWrongTypeOfOutputAdvanced < Actor
   output :name,
          type: {
            is: String,
-           message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
+           message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
              "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
              "Expected: `#{expected_type_names}`"
            end)

--- a/spec/examples/set_wrong_type_of_output_advanced.rb
+++ b/spec/examples/set_wrong_type_of_output_advanced.rb
@@ -5,7 +5,7 @@ class SetWrongTypeOfOutputAdvanced < Actor
   output :name,
          type: {
            is: String,
-           message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
+           message: (lambda do |input_key:, expected_type_names:, actual_type_name:, **|
              "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
              "Expected: `#{expected_type_names}`"
            end)

--- a/spec/examples/set_wrong_type_of_output_advanced.rb
+++ b/spec/examples/set_wrong_type_of_output_advanced.rb
@@ -5,7 +5,7 @@ class SetWrongTypeOfOutputAdvanced < Actor
   output :name,
          type: {
            class_name: String,
-           message: (lambda do |_kind, input_key, _service_name, expected_type_names, actual_type_name|
+           message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
              "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
              "Expected: `#{expected_type_names}`"
            end)

--- a/spec/examples/set_wrong_type_of_output_advanced.rb
+++ b/spec/examples/set_wrong_type_of_output_advanced.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
 class SetWrongTypeOfOutputAdvanced < Actor
-  # rubocop:disable Layout/LineLength
   output :name,
          type: {
            is: String,
-           message: (lambda do |input_key:, expected_type_names:, actual_type_name:, **|
-             "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
-             "Expected: `#{expected_type_names}`"
+           message: (lambda do |input_key:, expected_type:, given_type:, **|
+             "Wrong type `#{given_type}` for `#{input_key}`. " \
+             "Expected: `#{expected_type}`"
            end)
          }
-  # rubocop:enable Layout/LineLength
-
   def call
     self.name = 42
   end

--- a/spec/examples/set_wrong_type_of_output_advanced.rb
+++ b/spec/examples/set_wrong_type_of_output_advanced.rb
@@ -4,7 +4,7 @@ class SetWrongTypeOfOutputAdvanced < Actor
   # rubocop:disable Layout/LineLength
   output :name,
          type: {
-           class_name: String,
+           is: String,
            message: (lambda do |_kind, input_key, _service_name, actual_type_name, expected_type_names|
              "Wrong type `#{actual_type_name}` for `#{input_key}`. " \
              "Expected: `#{expected_type_names}`"


### PR DESCRIPTION
This PR adds advanced mode support for using `input` and `output`. This includes `message` support for customizing the error message.

For example, if necessary, this variant of the code:

```ruby
input :bonus_applied, type: [TrueClass, FalseClass]
```

Can be written as follows:

```ruby
input :bonus_applied,
      type: {
        is: [TrueClass, FalseClass],
        message: (lambda do |origin:, input_key:, actor:, expected_type:, given_type:|
          "Wrong type \"#{given_type}\" for \"#{input_key}\". " \
          "Expected: \"#{expected_type}\""
        end)
      }
```

---

### All examples of advanced mode

#### Collectionable

```ruby
class Pay < Actor
  input :provider,
        inclusion: {
          in: ["MANGOPAY", "PayPal", "Stripe"],
          message: (lambda do |input_key:, actor:, inclusion_in:, value:|
            "Payment system \"#{value}\" is not supported"
          end)
        }
end
```

#### Conditionable

```ruby
class Pay < Actor
  input :provider,
        must: {
          exist: {
            is: -> provider { PROVIDERS.include?(provider) },
            message: (lambda do |input_key:, check_name:, actor:, value:|
              "The specified provider \"#{value}\" was not found."
            end)
          }
        }
end
```

#### Defaultable

```ruby
  input :multiplier,
        default: {
          is: -> { rand(1..10) },
          message: (lambda do |input_key:, actor:|
            "Input \"#{input_key}\" is required"
          end)
        }
end
```

#### TypeCheckable

```ruby
class ReduceOrderAmount < Actor
  input :bonus_applied,
        type: {
          is: [TrueClass, FalseClass],
          message: (lambda do |origin:, input_key:, actor:, expected_type:, given_type:|
            "Wrong type \"#{given_type}\" for \"#{input_key}\". " \
            "Expected: \"#{expected_type}\""
          end)
        }
end
```

#### NilCheckable

```ruby
class CreateUser < Actor
  input :name,
        allow_nil: {
          is: false,
          message: (lambda do |origin:, input_key:, actor:|
            "The value \"#{input_key}\" cannot be empty"
          end)
        }
end
```