### PR TITLE
Prefer "inclusion" argument to "in" 🐹

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## unreleased
 
+Features:
+- Rename the `in:` option to `inclusion:`.
+
 ## v3.3.0
 
 Features:

--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ end
 
 ### Conditions
 
-You can ensure an input is included in a collection by using `in`:
+You can ensure an input is included in a collection by using `inclusion`:
 
 ```rb
 class Pay < Actor
-  input :currency, in: %w[EUR USD]
+  input :currency, inclusion: %w[EUR USD]
 
   # …
 end

--- a/lib/service_actor/collectionable.rb
+++ b/lib/service_actor/collectionable.rb
@@ -6,7 +6,7 @@
 # Example:
 #
 #   class Pay < Actor
-#     input :provider, in: ["MANGOPAY", "PayPal", "Stripe"]
+#     input :provider, inclusion: ["MANGOPAY", "PayPal", "Stripe"]
 #   end
 module ServiceActor::Collectionable
   def self.included(base)
@@ -16,12 +16,14 @@ module ServiceActor::Collectionable
   module PrependedMethods
     def _call
       self.class.inputs.each do |key, options|
-        next unless options[:in]
+        # DEPRECATED: `in` is deprecated in favor of `inclusion`.
+        inclusion = options[:inclusion] || options[:in]
+        next unless inclusion
 
-        next if options[:in].include?(result[key])
+        next if inclusion.include?(result[key])
 
         raise ArgumentError,
-              "Input #{key} must be included in #{options[:in].inspect} " \
+              "Input #{key} must be included in #{inclusion.inspect} " \
               "but instead was #{result[key].inspect}"
       end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -384,6 +384,34 @@ RSpec.describe Actor do
       end
     end
 
+    context 'when using "inclusion"' do
+      context "when given a correct value" do
+        it "returns the message" do
+          actor = PayWithProviderInclusion.call(provider: "PayPal")
+          expect(actor.message).to eq("Money transferred to PayPal!")
+        end
+      end
+
+      context "when given an incorrect value" do
+        let(:expected_alert) do
+          "Input provider must be included in " \
+            '["MANGOPAY", "PayPal", "Stripe"] but instead was "Paypal"'
+        end
+
+        it "fails" do
+          expect { PayWithProviderInclusion.call(provider: "Paypal") }
+            .to raise_error(expected_alert)
+        end
+      end
+
+      context "when it has a default" do
+        it "uses it" do
+          actor = PayWithProviderInclusion.call
+          expect(actor.message).to eq("Money transferred to Stripe!")
+        end
+      end
+    end
+
     context 'when using "in"' do
       context "when given a correct value" do
         it "returns the message" do

--- a/spec/examples/pay_with_provider_inclusion.rb
+++ b/spec/examples/pay_with_provider_inclusion.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class PayWithProviderInclusion < Actor
+  input :provider, inclusion: %w[MANGOPAY PayPal Stripe], default: "Stripe"
+  output :message, type: String
+
+  def call
+    self.message = "Money transferred to #{provider}!"
+  end
+end


### PR DESCRIPTION
Following #82, the name `inclusion` is clearer than `in` for input arguments.

Deprecation-wise, the idea is to:
- in this patch, soft-deprecate the `in` argument by allowing both syntaxes and removing the previous syntax from the documentation,
- later, deprecate the `in` argument with a warning on use,
- later, drop the `in` argument, on a major version upgrade.