### PR TITLE
Allow default to accept a lambda with context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## unreleased
 
+- `default` lambdas optionally accept a `context` with other attributes (#112)
+
 ## v3.6.1 
 
 Fixes:

--- a/README.md
+++ b/README.md
@@ -294,23 +294,27 @@ end
 
 ### Defaults
 
-Inputs can be optional by providing a default:
+Inputs can be optional by providing a `default` value or lambda.
 
 ```rb
 class BuildGreeting < Actor
   input :name
   input :adjective, default: "wonderful"
   input :length_of_time, default: -> { ["day", "week", "month"].sample }
+  input :article, default: -> context { context.adjective =~ /^aeiou/ ? 'an' : 'a' }
 
   output :greeting
 
   def call
-    self.greeting = "Have a #{adjective} #{length_of_time} #{name}!"
+    self.greeting = "Have #{article} #{length_of_time}, #{name}!"
   end
 end
 
 actor = BuildGreeting.call(name: "Jim")
-actor.greeting # => "Have a wonderful week Jim!"
+actor.greeting # => "Have a wonderful week, Jim!"
+
+actor = BuildGreeting.call(name: "Siobhan", adjective: "elegant")
+actor.greeting # => "Have an elegant week, Siobhan!"
 ```
 
 ### Allow nil

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -56,8 +56,7 @@ module ServiceActor::Defaultable
     private
 
     def default_for_normal_mode_with(result, key, default)
-      default = default.call if default.is_a?(Proc)
-      result[key] = default
+      result[key] = reify_default(result, default)
     end
 
     def default_for_advanced_mode_with(result, key, content)
@@ -67,8 +66,7 @@ module ServiceActor::Defaultable
         raise_error_with(message, input_key: key, actor: self.class)
       end
 
-      default = default.call if default.is_a?(Proc)
-      result[key] = default
+      result[key] = reify_default(result, default)
 
       message.call(key, self.class)
     end
@@ -78,6 +76,12 @@ module ServiceActor::Defaultable
       message = message.call(**arguments) if message.is_a?(Proc)
 
       raise self.class.argument_error_class, message
+    end
+
+    def reify_default(result, default)
+      return default unless default.is_a?(Proc)
+
+      default.arity.zero? ? default.call : default.call(result)
     end
   end
 end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -104,6 +104,13 @@ RSpec.describe Actor do
       end
     end
 
+    context "when a lambda default references other inputs" do
+      it "adds the computed default" do
+        actor = LambdaDefaultWithReference.call(old_project_id: 77_392)
+        expect(actor.project_id).to eq("77392.0")
+      end
+    end
+
     context "when an input has not been given" do
       it "raises an error" do
         expect { SetNameToDowncase.call }

--- a/spec/examples/lambda_default_with_reference.rb
+++ b/spec/examples/lambda_default_with_reference.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class LambdaDefaultWithReference < Actor
+  input :old_project_id, type: Integer
+  input :project_id,
+        default: -> context { "#{context.old_project_id}.0" },
+        type: String
+  output :properties, type: Hash
+
+  def call
+    self.properties = { project_id: project_id }
+  end
+end


### PR DESCRIPTION
If `default` is a `Proc` and has `arity == 1`, call it with the context that has been built so far. This lets actors implement defaults that are based on other values.

Closes #101