### PR TITLE
Forbid sending undefined messages to `ServiceActor::Result` instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Fixes:
 - Allow using a Hash as `default:` (#119)
 - Refactor `ServiceActor::Result` to get rid of `OpenStruct` inheritance
   (#127)
+- Deprecate invoking undefined methods on `ServiceActor::Result` (#129)
 - Ensure provided `failure_class` and `argument_error_class` values
   are subclasses of `Exception` (#132)
 - Skip `default` check for actor outputs (#135)

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -15,6 +15,10 @@ module ServiceActor::Core
       instance = new(result)
       instance._call
 
+      outputs.each_key do |key|
+        result.send("#{key}=", nil) unless result.respond_to?(key)
+      end
+
       result
     end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -833,5 +833,35 @@ RSpec.describe Actor do
       it { expect(actor.name).to eq("Jim") }
       it { expect(actor.value).to eq(0) }
     end
+
+    context "with sending unexpected messages" do
+      let(:actor) { PlayActors.result(value: 42) }
+
+      before { allow(Kernel).to receive(:warn) }
+
+      it { expect(actor).to be_a_success }
+      it { expect(actor).to respond_to(:name) }
+      it { expect(actor).to respond_to(:name?) }
+      it { expect(actor.name).to eq("jim") }
+
+      it { expect(actor).not_to respond_to(:unknown_method) }
+      it { expect(actor).not_to respond_to(:unknown_method?) }
+
+      it "warns about sending unexpected messages" do
+        actor.unknown_method
+
+        expect(Kernel).to have_received(:warn).with(
+          include("unknown_method"),
+        )
+      end
+
+      it "warns about sending unexpected predicate messages" do
+        actor.unknown_method?
+
+        expect(Kernel).to have_received(:warn).with(
+          include("unknown_method?"),
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/sunny/actor/issues/53