### PR TITLE
Verify configurable exception classes in setter method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Fixes:
 - Allow using a Hash as `default:` (#119)
 - Refactor `ServiceActor::Result` to get rid of `OpenStruct` inheritance
   (#127)
+- Ensure provided `failure_class` and `argument_error_class` values
+  are subclasses of `Exception` (#132)
 
 ## v3.7.0
 

--- a/lib/service_actor/configurable.rb
+++ b/lib/service_actor/configurable.rb
@@ -15,6 +15,26 @@ module ServiceActor::Configurable
       child.failure_class = failure_class || ServiceActor::Failure
     end
 
-    attr_accessor :argument_error_class, :failure_class
+    def argument_error_class=(value)
+      validate_provided_error_class(value)
+
+      @argument_error_class = value
+    end
+
+    def failure_class=(value)
+      validate_provided_error_class(value)
+
+      @failure_class = value
+    end
+
+    attr_reader :argument_error_class, :failure_class
+
+    private
+
+    def validate_provided_error_class(value)
+      return if value.is_a?(Class) && value <= Exception
+
+      raise ArgumentError, "Expected #{value} to be a subclass of Exception"
+    end
   end
 end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -720,6 +720,62 @@ RSpec.describe Actor do
         end
       end
     end
+
+    context "with `failure_class` which is not a class" do
+      let(:actor) do
+        Class.new(Actor) do
+          self.failure_class = 1
+        end
+      end
+
+      it do
+        expect { actor }.to raise_error(
+          ArgumentError, "Expected 1 to be a subclass of Exception"
+        )
+      end
+    end
+
+    context "with `failure_class` that does not inherit `Exception`" do
+      let(:actor) do
+        Class.new(Actor) do
+          self.failure_class = Class.new
+        end
+      end
+
+      it do
+        expect { actor }.to raise_error(
+          ArgumentError, /Expected .+ to be a subclass of Exception/
+        )
+      end
+    end
+
+    context "with `argument_error_class` which is not a class" do
+      let(:actor) do
+        Class.new(Actor) do
+          self.argument_error_class = 1
+        end
+      end
+
+      it do
+        expect { actor }.to raise_error(
+          ArgumentError, "Expected 1 to be a subclass of Exception"
+        )
+      end
+    end
+
+    context "with `argument_error_class` that does not inherit `Exception`" do
+      let(:actor) do
+        Class.new(Actor) do
+          self.argument_error_class = Class.new
+        end
+      end
+
+      it do
+        expect { actor }.to raise_error(
+          ArgumentError, /Expected .+ to be a subclass of Exception/
+        )
+      end
+    end
   end
 
   describe "#result" do


### PR DESCRIPTION
I doubt anyone will intentionally set argument_error_class/failure_class to some non-exception objects, but it's possible due to dummy mistake or misunderstanding. The problem here is that it wont be noticed until we try to raise something unraisable in actor failure scenario

So I think we can be a little be more defensive here

@sunny I'll add a changelog entry if you approve the idea