### PR TITLE
Add pattern matching support for Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## unreleased
 
+Features:
+- Add pattern matching support for `ServiceActor::Result` (#134)
+
 Changes:
 - Drop support for Ruby before 2.7 (#126)
 

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -76,6 +76,12 @@ class ServiceActor::Result < BasicObject
       respond_to_missing?(method_name, include_private)
   end
 
+  def deconstruct_keys(keys)
+    deconstructed_keys = to_h.merge(success: success?, failure: failure?)
+
+    keys ? deconstructed_keys.slice(*keys) : deconstructed_keys
+  end
+
   private
 
   attr_reader :data

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -950,5 +950,26 @@ RSpec.describe Actor do
         )
       end
     end
+
+    context "when using pattern matching" do
+      let(:successful_result) { FailForDifferentReasons.result(month: 2) }
+      let(:holidays_result) { FailForDifferentReasons.result(month: 12) }
+      let(:invalid_result) { FailForDifferentReasons.result(month: -1) }
+
+      it { expect(match_result(successful_result)).to eq "Welcome!" }
+      it { expect(match_result(holidays_result)).to eq "Come next year!" }
+      it { expect(match_result(invalid_result)).to be_nil }
+
+      def match_result(result)
+        case result
+        in {success: true, message:}
+          message
+        in {failure: true, reason: :holidays, message:}
+          message
+        in {failure: true, reason: :invalid_month}
+          nil
+        end
+      end
+    end
   end
 end

--- a/spec/examples/fail_for_different_reasons.rb
+++ b/spec/examples/fail_for_different_reasons.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class FailForDifferentReasons < Actor
+  input :month, type: Integer
+
+  output :message, type: String
+
+  def call
+    if month < 1 || month > 12
+      fail!(reason: :invalid_month)
+    elsif month == 12
+      self.message = "Come next year!"
+      fail!(reason: :holidays)
+    else
+      self.message = "Welcome!"
+    end
+  end
+end

--- a/spec/service_actor/result_spec.rb
+++ b/spec/service_actor/result_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ServiceActor::Result do
         :fail!,
         :class,
         :success?,
+        :deconstruct_keys,
         :[]=,
         :[],
         :kind_of?,


### PR DESCRIPTION
Fixes: https://github.com/sunny/actor/issues/133

I'm not sure if we should use `success?: true, failure?: false` or `success: true, failure: false`. Since we are handling hashes, I don't like the `?` on keys.

ps. There is error on linter because it is using Ruby 2.4 parser and pattern matching is supported on >= 2.7. It can be fixed with: 
```yml
# .rubocop.yml
AllCops:
  TargetRubyVersion: 3.0 # or 2.7
```
But it will recommend another improvements on other files.
