### PR TITLE
Verify `fail_on` DSL arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Fixes:
 - Ensure provided `failure_class` and `argument_error_class` values
   are subclasses of `Exception` (#132)
 - Skip `default` check for actor outputs (#135)
+- Ensure provided `fail_on` arguments are subclasses of `Exception` (#136)
 
 ## v3.7.0
 

--- a/lib/service_actor/arguments_validator.rb
+++ b/lib/service_actor/arguments_validator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ServiceActor::ArgumentsValidator
+  module_function
+
+  def validate_error_class(value)
+    return if value.is_a?(Class) && value <= Exception
+
+    raise ArgumentError, "Expected #{value} to be a subclass of Exception"
+  end
+end

--- a/lib/service_actor/configurable.rb
+++ b/lib/service_actor/configurable.rb
@@ -16,25 +16,17 @@ module ServiceActor::Configurable
     end
 
     def argument_error_class=(value)
-      validate_provided_error_class(value)
+      ServiceActor::ArgumentsValidator.validate_error_class(value)
 
       @argument_error_class = value
     end
 
     def failure_class=(value)
-      validate_provided_error_class(value)
+      ServiceActor::ArgumentsValidator.validate_error_class(value)
 
       @failure_class = value
     end
 
     attr_reader :argument_error_class, :failure_class
-
-    private
-
-    def validate_provided_error_class(value)
-      return if value.is_a?(Class) && value <= Exception
-
-      raise ArgumentError, "Expected #{value} to be a subclass of Exception"
-    end
   end
 end

--- a/lib/service_actor/failable.rb
+++ b/lib/service_actor/failable.rb
@@ -20,6 +20,10 @@ module ServiceActor::Failable
     end
 
     def fail_on(*exceptions)
+      exceptions.each do |exception|
+        ServiceActor::ArgumentsValidator.validate_error_class(exception)
+      end
+
       fail_ons.push(*exceptions)
     end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -785,6 +785,34 @@ RSpec.describe Actor do
         )
       end
     end
+
+    context "with `fail_on` which is not a class" do
+      let(:actor) do
+        Class.new(Actor) do
+          fail_on ArgumentError, "Some string", RuntimeError
+        end
+      end
+
+      it do
+        expect { actor }.to raise_error(
+          ArgumentError, "Expected Some string to be a subclass of Exception"
+        )
+      end
+    end
+
+    context "with `fail_on` which does not inherit `Exception`" do
+      let(:actor) do
+        Class.new(Actor) do
+          fail_on ArgumentError, Class.new
+        end
+      end
+
+      it do
+        expect { actor }.to raise_error(
+          ArgumentError, /Expected .+ to be a subclass of Exception/
+        )
+      end
+    end
   end
 
   describe "#result" do


### PR DESCRIPTION
Same as https://github.com/sunny/actor/pull/132

Currently passing invalid arguments to `fail_on` leads to runtime error only during actor's evaluation, not when the class is loaded