### PR TITLE
Verify origins do not collide with `ServiceActor::Result` object methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Fixes:
   are subclasses of `Exception` (#132)
 - Skip `default` check for actor outputs (#135)
 - Ensure provided `fail_on` arguments are subclasses of `Exception` (#136)
-- Ensure `input` and `output` names do not collide with
+- Ensure `input`, `output` and `alias_input` names do not collide with
   `ServiceActor::Result` instance methods (#138)
 
 ## v3.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Fixes:
   are subclasses of `Exception` (#132)
 - Skip `default` check for actor outputs (#135)
 - Ensure provided `fail_on` arguments are subclasses of `Exception` (#136)
+- Ensure `input` and `output` names do not collide with
+  `ServiceActor::Result` instance methods (#138)
 
 ## v3.7.0
 

--- a/lib/service_actor/arguments_validator.rb
+++ b/lib/service_actor/arguments_validator.rb
@@ -6,9 +6,12 @@ module ServiceActor::ArgumentsValidator
   def validate_origin_name(name, origin:)
     return unless ServiceActor::Result.instance_methods.include?(name.to_sym)
 
-    raise ArgumentError, <<~TXT
-      Defined #{origin} \`#{name}\` collides with `ServiceActor::Result` instance method
-    TXT
+    Kernel.warn(
+      "DEPRECATED: Defining inputs, outputs or alias_input that collide with " \
+      "`ServiceActor::Result` instance methods will lead to runtime errors " \
+      "in the next major release of Actor. " \
+      "Problematic #{origin}: `#{name}`",
+    )
   end
 
   def validate_error_class(value)

--- a/lib/service_actor/arguments_validator.rb
+++ b/lib/service_actor/arguments_validator.rb
@@ -6,12 +6,8 @@ module ServiceActor::ArgumentsValidator
   def validate_origin_name(name, origin:)
     return unless ServiceActor::Result.instance_methods.include?(name.to_sym)
 
-    Kernel.warn(
-      "DEPRECATED: Defining inputs, outputs or alias_input that collide with " \
-      "`ServiceActor::Result` instance methods will lead to runtime errors " \
-      "in the next major release of Actor. " \
-      "Problematic #{origin}: `#{name}`",
-    )
+    raise ArgumentError,
+          "#{origin} `#{name}` overrides `ServiceActor::Result` instance method"
   end
 
   def validate_error_class(value)

--- a/lib/service_actor/arguments_validator.rb
+++ b/lib/service_actor/arguments_validator.rb
@@ -3,6 +3,14 @@
 module ServiceActor::ArgumentsValidator
   module_function
 
+  def validate_origin_name(name, origin:)
+    return unless ServiceActor::Result.instance_methods.include?(name.to_sym)
+
+    raise ArgumentError, <<~TXT
+      Defined #{origin} \`#{name}\` collides with `ServiceActor::Result` instance method
+    TXT
+  end
+
   def validate_error_class(value)
     return if value.is_a?(Class) && value <= Exception
 

--- a/lib/service_actor/attributable.rb
+++ b/lib/service_actor/attributable.rb
@@ -20,6 +20,10 @@ module ServiceActor::Attributable
     end
 
     def input(name, **arguments)
+      ServiceActor::ArgumentsValidator.validate_origin_name(
+        name, origin: :input
+      )
+
       inputs[name] = arguments
 
       define_method(name) do
@@ -37,6 +41,10 @@ module ServiceActor::Attributable
     end
 
     def output(name, **arguments)
+      ServiceActor::ArgumentsValidator.validate_origin_name(
+        name, origin: :output
+      )
+
       outputs[name] = arguments
 
       define_method(name) do

--- a/lib/service_actor/playable.rb
+++ b/lib/service_actor/playable.rb
@@ -46,7 +46,7 @@ module ServiceActor::Playable
     private
 
     def define_alias_input(actor, new_input, original_input)
-      actor[new_input] = actor.__delete__(original_input)
+      actor[new_input] = actor.delete!(original_input)
     end
   end
 

--- a/lib/service_actor/playable.rb
+++ b/lib/service_actor/playable.rb
@@ -46,7 +46,7 @@ module ServiceActor::Playable
     private
 
     def define_alias_input(actor, new_input, original_input)
-      actor[new_input] = actor.delete(original_input)
+      actor[new_input] = actor.__delete__(original_input)
     end
   end
 

--- a/lib/service_actor/playable.rb
+++ b/lib/service_actor/playable.rb
@@ -20,6 +20,12 @@ module ServiceActor::Playable
     end
 
     def alias_input(**options)
+      options.each_key do |new|
+        ServiceActor::ArgumentsValidator.validate_origin_name(
+          new, origin: :alias
+        )
+      end
+
       lambda do |actor|
         options.each do |new, original|
           define_alias_input(actor, new, original)

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 # Represents the context of an actor, holding the data from both its inputs
 # and outputs.
 class ServiceActor::Result
@@ -63,11 +61,6 @@ class ServiceActor::Result
 
   def delete(key)
     data.delete(key)
-  end
-
-  # Defined here to override the method on `Object`.
-  def display
-    to_h.fetch(:display)
   end
 
   private

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -10,8 +10,8 @@ class ServiceActor::Result < BasicObject
     new(data.to_h)
   end
 
-  %i[class respond_to? is_a? kind_of? send].each do |mid|
-    define_method(mid, ::Kernel.instance_method(mid))
+  %i[class is_a? kind_of? send].each do |method_name|
+    define_method(method_name, ::Kernel.instance_method(method_name))
   end
 
   def initialize(data = {})
@@ -65,7 +65,7 @@ class ServiceActor::Result < BasicObject
     data[key] = value
   end
 
-  def __delete__(key)
+  def delete!(key)
     data.delete(key)
   end
 

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -10,7 +10,7 @@ class ServiceActor::Result < BasicObject
     new(data.to_h)
   end
 
-  %i[class respond_to? is_a? kind_of? object_id send].each do |mid|
+  %i[class respond_to? is_a? kind_of? send].each do |mid|
     define_method(mid, ::Kernel.instance_method(mid))
   end
 
@@ -65,7 +65,7 @@ class ServiceActor::Result < BasicObject
     data[key] = value
   end
 
-  def delete(key)
+  def __delete__(key)
     data.delete(key)
   end
 

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -3,7 +3,6 @@
 # Represents the context of an actor, holding the data from both its inputs
 # and outputs.
 
-# WIP
 class ServiceActor::Result < BasicObject
   def self.to_result(data)
     return data if data.is_a?(self)

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -423,12 +423,6 @@ RSpec.describe Actor do
       end
     end
 
-    context "when using an output called display" do
-      it "returns it" do
-        expect(SetOutputCalledDisplay.call.display).to eq("Foobar")
-      end
-    end
-
     context "when setting an unknown output" do
       it "raises" do
         expect { SetUnknownOutput.call }
@@ -727,6 +721,40 @@ RSpec.describe Actor do
 
         expect(actor).to be_a_success
         expect(actor.value).to be_nil
+      end
+    end
+
+    context "with `input` name that collides with result methods" do
+      let(:actor) do
+        Class.new(Actor) do
+          input :value, type: Integer
+          input :object_id, type: String
+        end
+      end
+
+      it "raises `ArgumentError` exception" do
+        expect { actor }.to raise_error(
+          ArgumentError, <<~TXT
+            Defined input `object_id` collides with `ServiceActor::Result` instance method
+          TXT
+        )
+      end
+    end
+
+    context "with `output` name that collides with result methods" do
+      let(:actor) do
+        Class.new(Actor) do
+          input :value, type: Integer
+          output :display, type: String
+        end
+      end
+
+      it "raises `ArgumentError` exception" do
+        expect { actor }.to raise_error(
+          ArgumentError, <<~TXT
+            Defined output `display` collides with `ServiceActor::Result` instance method
+          TXT
+        )
       end
     end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -745,14 +745,14 @@ RSpec.describe Actor do
       let(:actor) do
         Class.new(Actor) do
           input :value, type: Integer
-          output :display, type: String
+          output :send, type: String
         end
       end
 
       it "raises `ArgumentError` exception" do
         expect { actor }.to raise_error(
           ArgumentError, <<~TXT
-            Defined output `display` collides with `ServiceActor::Result` instance method
+            Defined output `send` collides with `ServiceActor::Result` instance method
           TXT
         )
       end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -739,11 +739,10 @@ RSpec.describe Actor do
       end
 
       specify do
-        actor
-
-        expect(Kernel).to have_received(:warn)
-          .with(/DEPRECATED: Defining inputs, .* input: `kind_of\?`/)
-          .once
+        expect { actor }.to raise_error(
+          ArgumentError,
+          "input `kind_of?` overrides `ServiceActor::Result` instance method",
+        )
       end
     end
 
@@ -758,11 +757,10 @@ RSpec.describe Actor do
       end
 
       specify do
-        actor
-
-        expect(Kernel).to have_received(:warn)
-          .with(/DEPRECATED: Defining inputs, .* output: `fail!`/)
-          .once
+        expect { actor }.to raise_error(
+          ArgumentError,
+          "output `fail!` overrides `ServiceActor::Result` instance method",
+        )
       end
     end
 
@@ -778,11 +776,10 @@ RSpec.describe Actor do
       end
 
       specify do
-        actor
-
-        expect(Kernel).to have_received(:warn)
-          .with(/DEPRECATED: Defining inputs, .* alias: `merge!`/)
-          .once
+        expect { actor }.to raise_error(
+          ArgumentError,
+          "alias `merge!` overrides `ServiceActor::Result` instance method",
+        )
       end
     end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -734,7 +734,7 @@ RSpec.describe Actor do
       let(:actor) do
         Class.new(Actor) do
           input :value, type: Integer
-          input :object_id, type: String
+          input :kind_of?, type: String
         end
       end
 
@@ -742,7 +742,7 @@ RSpec.describe Actor do
         actor
 
         expect(Kernel).to have_received(:warn)
-          .with(/DEPRECATED: Defining inputs, .* input: `object_id`/)
+          .with(/DEPRECATED: Defining inputs, .* input: `kind_of\?`/)
           .once
       end
     end
@@ -753,7 +753,7 @@ RSpec.describe Actor do
       let(:actor) do
         Class.new(Actor) do
           input :value, type: Integer
-          output :send, type: String
+          output :fail!, type: String
         end
       end
 
@@ -761,7 +761,7 @@ RSpec.describe Actor do
         actor
 
         expect(Kernel).to have_received(:warn)
-          .with(/DEPRECATED: Defining inputs, .* output: `send`/)
+          .with(/DEPRECATED: Defining inputs, .* output: `fail!`/)
           .once
       end
     end
@@ -773,7 +773,7 @@ RSpec.describe Actor do
         Class.new(Actor) do
           input :value, type: Integer
 
-          play alias_input(object_id: :value)
+          play alias_input(merge!: :value)
         end
       end
 
@@ -781,7 +781,7 @@ RSpec.describe Actor do
         actor
 
         expect(Kernel).to have_received(:warn)
-          .with(/DEPRECATED: Defining inputs, .* alias: `object_id`/)
+          .with(/DEPRECATED: Defining inputs, .* alias: `merge!`/)
           .once
       end
     end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -758,6 +758,24 @@ RSpec.describe Actor do
       end
     end
 
+    context "with `alias_input` that collides with result methods" do
+      let(:actor) do
+        Class.new(Actor) do
+          input :value, type: Integer
+
+          play alias_input(object_id: :value)
+        end
+      end
+
+      it "raises `ArgumentError` exception" do
+        expect { actor }.to raise_error(
+          ArgumentError, <<~TXT
+            Defined alias `object_id` collides with `ServiceActor::Result` instance method
+          TXT
+        )
+      end
+    end
+
     context "with `failure_class` which is not a class" do
       let(:actor) do
         Class.new(Actor) do

--- a/spec/examples/set_output_called_display.rb
+++ b/spec/examples/set_output_called_display.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class SetOutputCalledDisplay < Actor
-  output :display
-
-  def call
-    self.display = "Foobar"
-  end
-end

--- a/spec/service_actor/arguments_validator_spec.rb
+++ b/spec/service_actor/arguments_validator_spec.rb
@@ -2,21 +2,20 @@
 
 RSpec.describe ServiceActor::ArgumentsValidator do
   describe ".validate_origin_name" do
-    let(:expected_error_message) do
-      <<~TXT
-        Defined input `fail!` collides with `ServiceActor::Result` instance method
-      TXT
-    end
+    before { allow(Kernel).to receive(:warn).with(kind_of(String)) }
 
     it "raises if collision present" do
-      expect { described_class.validate_origin_name(:fail!, origin: :input) }
-        .to raise_error(ArgumentError, expected_error_message)
+      described_class.validate_origin_name(:fail!, origin: :input)
+
+      expect(Kernel).to have_received(:warn)
+        .with(/DEPRECATED: Defining inputs, .* input: `fail!`/)
+        .once
     end
 
     it do
-      expect do
-        described_class.validate_origin_name(:some_method, origin: :output)
-      end.not_to raise_error
+      described_class.validate_origin_name(:some_method, origin: :output)
+
+      expect(Kernel).not_to have_received(:warn)
     end
   end
 

--- a/spec/service_actor/arguments_validator_spec.rb
+++ b/spec/service_actor/arguments_validator_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe ServiceActor::ArgumentsValidator do
+  describe ".validate_origin_name" do
+    let(:expected_error_message) do
+      <<~TXT
+        Defined input `to_s` collides with `ServiceActor::Result` instance method
+      TXT
+    end
+
+    it "raises if collision present" do
+      expect { described_class.validate_origin_name(:to_s, origin: :input) }
+        .to raise_error(ArgumentError, expected_error_message)
+    end
+
+    it do
+      expect do
+        described_class.validate_origin_name(:some_method, origin: :output)
+      end.not_to raise_error
+    end
+  end
+
+  describe ".validate_error_class" do
+    it "with an exception class" do
+      expect { described_class.validate_error_class(ArgumentError) }
+        .not_to raise_error
+    end
+
+    it "with a non-class object" do
+      expect { described_class.validate_error_class("123") }
+        .to raise_error(
+          ArgumentError,
+          "Expected 123 to be a subclass of Exception",
+        )
+    end
+
+    it "with a non-exception class" do
+      expect { described_class.validate_error_class(Class.new) }
+        .to raise_error(
+          ArgumentError,
+          /Expected .+ to be a subclass of Exception/,
+        )
+    end
+  end
+end

--- a/spec/service_actor/arguments_validator_spec.rb
+++ b/spec/service_actor/arguments_validator_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe ServiceActor::ArgumentsValidator do
   describe ".validate_origin_name" do
     let(:expected_error_message) do
       <<~TXT
-        Defined input `to_s` collides with `ServiceActor::Result` instance method
+        Defined input `fail!` collides with `ServiceActor::Result` instance method
       TXT
     end
 
     it "raises if collision present" do
-      expect { described_class.validate_origin_name(:to_s, origin: :input) }
+      expect { described_class.validate_origin_name(:fail!, origin: :input) }
         .to raise_error(ArgumentError, expected_error_message)
     end
 

--- a/spec/service_actor/arguments_validator_spec.rb
+++ b/spec/service_actor/arguments_validator_spec.rb
@@ -2,20 +2,19 @@
 
 RSpec.describe ServiceActor::ArgumentsValidator do
   describe ".validate_origin_name" do
-    before { allow(Kernel).to receive(:warn).with(kind_of(String)) }
-
-    it "raises if collision present" do
-      described_class.validate_origin_name(:fail!, origin: :input)
-
-      expect(Kernel).to have_received(:warn)
-        .with(/DEPRECATED: Defining inputs, .* input: `fail!`/)
-        .once
+    it "raises if collision present" do # rubocop:disable RSpec/ExampleLength
+      expect do
+        described_class.validate_origin_name(:fail!, origin: :input)
+      end.to raise_error(
+        ArgumentError,
+        "input `fail!` overrides `ServiceActor::Result` instance method",
+      )
     end
 
     it do
-      described_class.validate_origin_name(:some_method, origin: :output)
-
-      expect(Kernel).not_to have_received(:warn)
+      expect do
+        described_class.validate_origin_name(:some_method, origin: :output)
+      end.not_to raise_error
     end
   end
 

--- a/spec/service_actor/result_spec.rb
+++ b/spec/service_actor/result_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ServiceActor::Result do
       expect(described_class.instance_methods).to contain_exactly(
         :merge!,
         :send,
-        :__delete__,
+        :delete!,
         :key?,
         :pretty_print,
         :failure?,

--- a/spec/service_actor/result_spec.rb
+++ b/spec/service_actor/result_spec.rb
@@ -9,6 +9,38 @@ RSpec.describe ServiceActor::Result do
     expect(result.respond_to?(:name?)).to be true
   end
 
+  describe ".instance_methods" do
+    it "stays the same across supported Rubies" do # rubocop:disable RSpec/ExampleLength
+      expect(described_class.instance_methods).to contain_exactly(
+        :merge!,
+        :send,
+        :__delete__,
+        :key?,
+        :pretty_print,
+        :failure?,
+        :inspect,
+        :fail!,
+        :class,
+        :success?,
+        :[]=,
+        :[],
+        :kind_of?,
+        :is_a?,
+        :respond_to?,
+        :to_h,
+        :equal?,
+        :!,
+        :__send__,
+        :==,
+        :!=,
+        :__binding__,
+        :instance_eval,
+        :instance_exec,
+        :__id__,
+      )
+    end
+  end
+
   context "when input is String" do
     context "when is empty" do
       it "returns false" do

--- a/spec/service_actor/version_spec.rb
+++ b/spec/service_actor/version_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
 RSpec.describe ServiceActor::VERSION do
-  # rubocop:disable RSpec/DescribedClass
-  it { expect(ServiceActor::VERSION).not_to be_nil }
-  # rubocop:enable RSpec/DescribedClass
+  it { is_expected.not_to be_nil }
 end


### PR DESCRIPTION
Resolves https://github.com/sunny/actor/issues/137

I'm not sure about removing display-related tests and code, but since we do not allow these methods in inputs/outputs seems like we dont have to be specific about `display`

Also added some tests and removed lonely `require ostruct`

```
> irb(main):004:0> RUBY_VERSION
> => "3.0.6"
> irb(main):005:0> ServiceActor::Result.instance_methods.to_s
> => "[:merge!, :key?, :inspect, :failure?, :delete, :[], :[]=, :fail!, :success?, :to_h, :pretty_print_instance_variables, :pretty_print_cycle, :pretty_print, :pretty_print_inspect, :taint, :tainted?, :untaint, :untrust, :untrusted?, :trust, :methods, :singleton_methods, :protected_methods, :private_methods, :public_methods, :instance_variables, :instance_variable_get, :instance_variable_set, :instance_variable_defined?, :remove_instance_variable, :instance_of?, :kind_of?, :is_a?, :gem, :class, :frozen?, :then, :public_send, :method, :public_method, :singleton_method, :tap, :define_singleton_method, :extend, :clone, :yield_self, :pretty_inspect, :to_enum, :enum_for, :<=>, :===, :=~, :!~, :nil?, :eql?, :respond_to?, :freeze, :object_id, :send, :to_s, :display, :hash, :singleton_class, :dup, :itself, :!, :==, :!=, :equal?, :instance_eval, :instance_exec, :__id__, :__send__]"
```
