### PR TITLE
Add simplecov as development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.5.1)
     diffy (3.4.2)
+    docile (1.4.0)
     interactor (3.1.2)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
@@ -95,6 +96,12 @@ GEM
     rubocop-thread_safety (0.5.1)
       rubocop (>= 0.90.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     standard (1.34.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -132,6 +139,7 @@ DEPENDENCIES
   rubocop-rake (>= 0.1)
   rubocop-rspec (>= 2.0)
   service_actor!
+  simplecov
 
 BUNDLED WITH
    2.3.17

--- a/service_actor.gemspec
+++ b/service_actor.gemspec
@@ -72,4 +72,7 @@ Gem::Specification.new do |spec|
 
   # For testing Interactor migration support
   spec.add_development_dependency "interactor", ">= 3.0"
+
+  # Code coverage reporter
+  spec.add_development_dependency "simplecov", ">= 0.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
+  add_filter "/spec"
+end
+
 require "bundler/setup"
 require "service_actor"
 require "pry"


### PR DESCRIPTION
Can we add simplecov to dev dependencies? It'd be much easier to reason about specs completeness