### PR TITLE
Fix incorrect outputs default value handling

### DIFF
--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -17,10 +17,6 @@ module ServiceActor::Core
       instance = new(result)
       instance._call
 
-      outputs.each_key do |key|
-        result.send(:"#{key}=", nil) unless result.respond_to?(key)
-      end
-
       result
     end
 

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -52,6 +52,12 @@ module ServiceActor::Defaultable
         end
       end
 
+      self.class.outputs.each do |key, options|
+        unless result.key?(key)
+          result.send(:"#{key}=", options[:default])
+        end
+      end
+
       super
     end
 

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -427,6 +427,13 @@ RSpec.describe Actor do
       end
     end
 
+    context "with accessing origins multiple times" do
+      it "returns expected value" do
+        expect(AccessOriginsMultipleTimes.call(value: 0).value_result).to eq(2)
+        expect(AccessOriginsMultipleTimes.call(value: 0).output_with_default).to eq(42)
+      end
+    end
+
     context "when setting an unknown output" do
       it "raises" do
         expect { SetUnknownOutput.call }

--- a/spec/examples/access_origins_multiple_times.rb
+++ b/spec/examples/access_origins_multiple_times.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AccessOriginsMultipleTimes < Actor
+  input :value, type: Integer
+
+  output :value_result, type: Integer
+  output :output_with_default, type: Integer, allow_nil: true, default: 42
+
+  play -> actor { actor.value_result = actor.value.succ }
+  play -> actor { actor.value_result += 1 }
+end


### PR DESCRIPTION
There are, actually, two bugfixes:

1. The first one fixes a bug from https://github.com/sunny/actor/pull/135. We stopped processing outputs with `DefaultCheck` which, surprisingly, was not pure and did mutate `result.outputs` by setting their defaults
2. The second on is related to these lines of code

https://github.com/sunny/actor/blob/b42ab64fb4e856311008f60ae8b2360e5f5e5b01/lib/service_actor/core.rb#L20-L22

the problem is that outputs were populated **after** playing the entire suite, so the following line would fail

```ruby
class A < Actor
  output :value

  play ->(actor) { actor.value = 1 } # this line will throw warning in runtime
end

A.call.value # this line wont throw warning in runtime
```

