### PR TITLE
Add .value() class method that gives the return value of actor's #call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## unreleased
 
+Features:
+- Add support for `output_of()` method on actors (#152)
+
 ## v3.8.1
 
 Fix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## unreleased
 
 Features:
-- Add support for `output_of()` method on actors (#152)
+- Add support for `value()` method on actors (#152)
 
 ## v3.8.1
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ class BuildGreeting < Actor
   end
 end
 
-BuildGreeting.output_of(name: 'Fred') # => "Have a wonderful day, Fred!"
+BuildGreeting.output_of(name: "Fred") # => "Have a wonderful day, Fred!"
 ```
 
 ### Fail

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ actor.greeting? # => true
 
 If you only have one value you want from an actor, you can skip defining an
 output by making it the return value of `.call()` and calling your actor with
-`.output_of()`:
+`.value()`:
 
 ```rb
 class BuildGreeting < Actor
@@ -136,7 +136,7 @@ class BuildGreeting < Actor
   end
 end
 
-BuildGreeting.output_of(name: "Fred") # => "Have a wonderful day, Fred!"
+BuildGreeting.value(name: "Fred") # => "Have a wonderful day, Fred!"
 ```
 
 ### Fail
@@ -199,7 +199,7 @@ Calling this actor will now call every actor along the way. Inputs and outputs
 will go from one actor to the next, all sharing the same result set until it is
 finally returned.
 
-If you use `.output_of()` to call this actor, it will give the return value of
+If you use `.value()` to call this actor, it will give the return value of
 the final actor in the play chain.
 
 ### Rollback

--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ actor.greeting # => "Have a wonderful day!"
 actor.greeting? # => true
 ```
 
+If you only have one value you want from an actor, you can skip defining an
+output by making it the return value of `.call()` and calling your actor with
+`.output_of()`:
+
+```rb
+class BuildGreeting < Actor
+  input :name
+
+  def call
+    "Have a wonderful day, #{name}!"
+  end
+end
+
+BuildGreeting.output_of(name: 'Fred') # => "Have a wonderful day, Fred!"
+```
+
 ### Fail
 
 To stop the execution and mark an actor as having failed, use `fail!`:
@@ -182,6 +198,9 @@ end
 Calling this actor will now call every actor along the way. Inputs and outputs
 will go from one actor to the next, all sharing the same result set until it is
 finally returned.
+
+If you use `.output_of()` to call this actor, it will give the return value of
+the final actor in the play chain.
 
 ### Rollback
 

--- a/lib/service_actor/base.rb
+++ b/lib/service_actor/base.rb
@@ -15,7 +15,7 @@ module ServiceActor::Base
       base.include(ServiceActor::Checkable)
       base.include(ServiceActor::Defaultable)
       base.include(ServiceActor::Failable)
-      base.include(ServiceActor::Outputable)
+      base.include(ServiceActor::Valuable)
     end
   end
 end

--- a/lib/service_actor/base.rb
+++ b/lib/service_actor/base.rb
@@ -15,6 +15,7 @@ module ServiceActor::Base
       base.include(ServiceActor::Checkable)
       base.include(ServiceActor::Defaultable)
       base.include(ServiceActor::Failable)
+      base.include(ServiceActor::Outputable)
     end
   end
 end

--- a/lib/service_actor/checkable.rb
+++ b/lib/service_actor/checkable.rb
@@ -20,8 +20,9 @@ module ServiceActor::Checkable
       self.service_actor_argument_errors = []
 
       service_actor_checks_for(:input)
-      super
+      return_val = super
       service_actor_checks_for(:output)
+      return_val
     end
 
     private

--- a/lib/service_actor/core.rb
+++ b/lib/service_actor/core.rb
@@ -45,6 +45,8 @@ module ServiceActor::Core
   # This method is used internally to override behavior on call. Overriding
   # `call` instead would mean that end-users have to call `super` in their
   # actors.
+  # When overriding and calling `super`, make sure the final value is the return
+  # value of `super` (see e.g. ServiceActor::Checkable).
   # :nodoc:
   def _call
     call

--- a/lib/service_actor/outputable.rb
+++ b/lib/service_actor/outputable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Adds the `fail_on` DSL to actors. This allows you to call `.result` and get
+# back a failed actor instead of raising an exception.
+#
+#   class ApplicationActor < Actor
+#     fail_on ServiceActor::ArgumentError
+#   end
+module ServiceActor::Outputable
+  class << self
+    def included(base)
+      base.extend(ClassMethods)
+      base.prepend(PrependedMethods)
+    end
+  end
+
+  module ClassMethods
+    def output_of(result = nil, **arguments)
+      call(result, **arguments)[:_default_output]
+    end
+  end
+
+  module PrependedMethods
+    def _call
+      result[:_default_output] = super
+    end
+  end
+end

--- a/lib/service_actor/outputable.rb
+++ b/lib/service_actor/outputable.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
-# Adds the `fail_on` DSL to actors. This allows you to call `.result` and get
-# back a failed actor instead of raising an exception.
+# Adds the `output` method to actors. This allows you to call `.output` and get
+# back the return value of that actor's `call` method.
 #
-#   class ApplicationActor < Actor
-#     fail_on ServiceActor::ArgumentError
+# In the case of play actors, it will return the value of the final actor's
+# `call` method in the chain.
+#
+#   class MyActor < Actor
+#     def call
+#       "foo"
+#     end
 #   end
+#
+#   > MyActor.output
+#   => "foo"
 module ServiceActor::Outputable
   class << self
     def included(base)

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -33,8 +33,6 @@ class ServiceActor::Result < BasicObject
   end
 
   def to_h
-    # default_output is an internal datum used by .output_of
-    # don't expose it with the rest of the result
     filter_default_output(data)
   end
 
@@ -105,8 +103,10 @@ class ServiceActor::Result < BasicObject
 
   attr_reader :data
 
+  # Key `_default_output` is an internal datum used by actor class
+  # method `.output`. Don't expose it with the rest of the result.
   def filter_default_output(h)
-    h.filter { |k| k != :_default_output }
+    h.except(:_default_output)
   end
 
   def respond_to_missing?(method_name, _include_private = false)

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -104,7 +104,7 @@ class ServiceActor::Result < BasicObject
   attr_reader :data
 
   # Key `_default_output` is an internal datum used by actor class
-  # method `.output`. Don't expose it with the rest of the result.
+  # method `.valuable`. Don't expose it with the rest of the result.
   def filter_default_output(h)
     # using `filter` instead of `except` to maintain Ruby 2.7 compatibility
     # update once support for 2.7 is dropped

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -33,7 +33,9 @@ class ServiceActor::Result < BasicObject
   end
 
   def to_h
-    data
+    # default_output is an internal datum used by .output_of
+    # don't expose it with the rest of the result
+    filter_default_output(data)
   end
 
   def inspect
@@ -102,6 +104,10 @@ class ServiceActor::Result < BasicObject
   private
 
   attr_reader :data
+
+  def filter_default_output(h)
+    h.filter { |k| k != :_default_output }
+  end
 
   def respond_to_missing?(method_name, _include_private = false)
     return true if method_name.end_with?("=")

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -106,7 +106,9 @@ class ServiceActor::Result < BasicObject
   # Key `_default_output` is an internal datum used by actor class
   # method `.output`. Don't expose it with the rest of the result.
   def filter_default_output(h)
-    h.except(:_default_output)
+    # using `filter` instead of `except` to maintain Ruby 2.7 compatibility
+    # update once support for 2.7 is dropped
+    h.filter { |k| k != :_default_output }
   end
 
   def respond_to_missing?(method_name, _include_private = false)

--- a/lib/service_actor/valuable.rb
+++ b/lib/service_actor/valuable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Adds the `output` method to actors. This allows you to call `.output` and get
+# Adds the `value` method to actors. This allows you to call `.value` and get
 # back the return value of that actor's `call` method.
 #
 # In the case of play actors, it will return the value of the final actor's
@@ -12,9 +12,9 @@
 #     end
 #   end
 #
-#   > MyActor.output
+#   > MyActor.value
 #   => "foo"
-module ServiceActor::Outputable
+module ServiceActor::Valuable
   class << self
     def included(base)
       base.extend(ClassMethods)
@@ -23,7 +23,7 @@ module ServiceActor::Outputable
   end
 
   module ClassMethods
-    def output_of(result = nil, **arguments)
+    def value(result = nil, **arguments)
       call(result, **arguments)[:_default_output]
     end
   end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Actor do
     context "when fail! is not called" do
       let(:output) { DoNothing.output_of }
 
-      it { expect(output).to eq nil }
+      it { expect(output).to be_nil }
     end
 
     context "when fail! is called" do

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -5,189 +5,6 @@ RSpec.describe Actor do
     before { allow(Kernel).to receive(:warn).with(kind_of(String)) }
   end
 
-  describe "#value" do
-    context "when fail! is not called" do
-      let(:output) { DoNothing.value }
-
-      it { expect(output).to be_nil }
-    end
-
-    context "when fail! is called" do
-      it "raises the error message" do
-        expect { FailWithError.value }
-          .to raise_error(ServiceActor::Failure, "Ouch")
-      end
-
-      context "when a custom class is specified" do
-        it "raises the error message" do
-          expect { FailWithErrorWithCustomFailureClass.value }
-            .to raise_error(MyCustomFailure, "Ouch")
-        end
-      end
-    end
-
-    context "when an actor updates the context using value" do
-      it "returns the value of the context change" do
-        output = AddNameToContext.value
-        expect(output).to eq("Jim")
-      end
-    end
-
-    context "when an actor updates the context with a hash using value" do
-      it "returns the hash value of the context change" do
-        output = AddHashToContext.value
-        expect(output).to eq(name: "Jim")
-      end
-    end
-
-    context "when an actor uses a method named after the input" do
-      it "returns what is assigned to the context" do
-        output = SetNameToDowncase.value(name: "JIM")
-        expect(output).to eq("jim")
-      end
-    end
-
-    context "when given a context instead of a hash" do
-      it "returns the value of the context" do
-        actor = ServiceActor::Result.new(name: "Jim")
-
-        expect(AddNameToContext.value(actor)).to eq("Jim")
-      end
-    end
-
-    context "when an actor changes a value" do
-      it "returns the updated value" do
-        expect(IncrementValue.value(value: 1)).to eq(2)
-      end
-    end
-
-    context "when an input has a default" do
-      it "can use it" do
-        expect(AddGreetingWithDefault.value).to eq("Hello, world!")
-      end
-
-      it "is overridden by values added to call" do
-        expect(AddGreetingWithDefault.value(name: "Jim")).to eq("Hello, Jim!")
-      end
-
-      it "is overridden by values already in the context" do
-        output = AddGreetingWithDefault.value(
-          ServiceActor::Result.new(name: "jim"),
-        )
-        expect(output).to eq("Hello, jim!")
-      end
-    end
-
-    context "when an input has a default that is a hash" do
-      it "can use it" do
-        expect(AddGreetingWithHashDefault.value).to eq("Hello, world!")
-      end
-
-      it "is overridden by values added to call" do
-        output = AddGreetingWithHashDefault.value(options: {name: "Alice"})
-        expect(output).to eq("Hello, Alice!")
-      end
-
-      it "is overridden by values already in the context" do
-        output = AddGreetingWithHashDefault.value(
-          ServiceActor::Result.new(options: {name: "Alice"}),
-        )
-        expect(output).to eq("Hello, Alice!")
-      end
-    end
-
-    context "when an input has a lambda default" do
-      it "can use it" do
-        output = AddGreetingWithLambdaDefault.value
-        expect(output).to eq("Hello, world!")
-      end
-    end
-
-    context "when a lambda default references other inputs" do
-      it "adds the computed default" do
-        output = LambdaDefaultWithReference.value(old_project_id: 77_392)
-        expect(output).to eq(project_id: "77392.0")
-      end
-    end
-
-    context "when an input has not been given" do
-      it "raises an error" do
-        expect { SetNameToDowncase.value }
-          .to raise_error(
-            ServiceActor::ArgumentError,
-            "The \"name\" input on \"SetNameToDowncase\" is missing",
-          )
-      end
-    end
-
-    context "when playing several actors" do
-      it "returns the result of the last actor" do
-        expect(PlayActors.value(value: 1)).to eq(3)
-      end
-
-      context "when not providing arguments" do
-        it "uses defaults from the inner actors" do
-          expect(PlayActors.value).to eq(2)
-        end
-      end
-    end
-
-    context "when playing actors and lambdas" do
-      it "calls the actors and lambdas in order and returns the final value" do
-        expect(PlayLambdas.value).to eq("jim number 4")
-      end
-    end
-
-    context "when playing actors and symbols" do
-      it "calls the actors and symbols in order and returns the final value" do
-        expect(PlayInstanceMethods.value).to eq("jim number 4")
-      end
-    end
-
-    context "when using `play` several times" do
-      it "shares the result between actors and returns the final value" do
-        expect(PlayMultipleTimes.value(value: 1)).to eq(3)
-      end
-    end
-
-    context "when using `play` with conditions" do
-      it "does not trigger actors with conditions and returns the final value" do
-        expect(PlayMultipleTimesWithConditions.value).to eq(3)
-      end
-    end
-
-    context "when using `play` with evaluated conditions" do
-      let(:output) do
-        PlayMultipleTimesWithEvaluatedConditions.value(callable: callable)
-      end
-      let(:callable) { -> {} }
-
-      before do
-        allow(callable).to receive(:call).and_return(true)
-      end
-
-      it "does not evaluate conditions multiple times" do
-        expect(output).to eq(4)
-        expect(callable).to have_received(:call).once
-      end
-    end
-
-    context "when playing several actors and one fails" do
-      let(:actor) { ServiceActor::Result.new(value: 0) }
-
-      it "raises with the message" do
-        expect { FailPlayingActionsWithRollback.value(actor) }
-          .to raise_error(ServiceActor::Failure, "Ouch")
-      end
-    end
-
-    context "when playing actors and alias_input" do
-      it "calls the actors and can be referenced by alias" do
-        expect(PlayAliasInput.value).to eq("jim number 1")
-      end
-    end
-  end
-
   describe "#call" do
     context "when fail! is not called" do
       let(:actor) { DoNothing.call }
@@ -1159,6 +976,443 @@ RSpec.describe Actor do
         in {failure: true, reason: :invalid_month}
           nil
         end
+      end
+    end
+  end
+
+  describe "#value" do
+    context "when fail! is not called" do
+      let(:output) { DoNothing.value }
+
+      it { expect(output).to be_nil }
+    end
+
+    context "when fail! is called" do
+      it "raises the error message" do
+        expect { FailWithError.value }
+          .to raise_error(ServiceActor::Failure, "Ouch")
+      end
+
+      context "when a custom class is specified" do
+        it "raises the error message" do
+          expect { FailWithErrorWithCustomFailureClass.value }
+            .to raise_error(MyCustomFailure, "Ouch")
+        end
+      end
+    end
+
+    context "when an actor updates the context using value" do
+      it "returns the value of the context change" do
+        output = AddNameToContext.value
+        expect(output).to eq("Jim")
+      end
+    end
+
+    context "when an actor updates the context with a hash using value" do
+      it "returns the hash value of the context change" do
+        output = AddHashToContext.value
+        expect(output).to eq(name: "Jim")
+      end
+    end
+
+    context "when an actor uses a method named after the input" do
+      it "returns what is assigned to the context" do
+        output = SetNameToDowncase.value(name: "JIM")
+        expect(output).to eq("jim")
+      end
+    end
+
+    context "when given a context instead of a hash" do
+      it "returns the value of the context" do
+        actor = ServiceActor::Result.new(name: "Jim")
+
+        expect(AddNameToContext.value(actor)).to eq("Jim")
+      end
+    end
+
+    context "when an actor changes a value" do
+      it "returns the updated value" do
+        expect(IncrementValue.value(value: 1)).to eq(2)
+      end
+    end
+
+    context "when an input has a default" do
+      it "can use it" do
+        expect(AddGreetingWithDefault.value).to eq("Hello, world!")
+      end
+
+      it "is overridden by values added to call" do
+        expect(AddGreetingWithDefault.value(name: "Jim")).to eq("Hello, Jim!")
+      end
+
+      it "is overridden by values already in the context" do
+        output = AddGreetingWithDefault.value(
+          ServiceActor::Result.new(name: "jim"),
+        )
+        expect(output).to eq("Hello, jim!")
+      end
+    end
+
+    context "when an input has a default that is a hash" do
+      it "can use it" do
+        expect(AddGreetingWithHashDefault.value).to eq("Hello, world!")
+      end
+
+      it "is overridden by values added to call" do
+        output = AddGreetingWithHashDefault.value(options: {name: "Alice"})
+        expect(output).to eq("Hello, Alice!")
+      end
+
+      it "is overridden by values already in the context" do
+        output = AddGreetingWithHashDefault.value(
+          ServiceActor::Result.new(options: {name: "Alice"}),
+        )
+        expect(output).to eq("Hello, Alice!")
+      end
+    end
+
+    context "when an input has a lambda default" do
+      it "can use it" do
+        output = AddGreetingWithLambdaDefault.value
+        expect(output).to eq("Hello, world!")
+      end
+    end
+
+    context "when a lambda default references other inputs" do
+      it "adds the computed default" do
+        output = LambdaDefaultWithReference.value(old_project_id: 77_392)
+        expect(output).to eq(project_id: "77392.0")
+      end
+    end
+
+    context "when an input has not been given" do
+      it "raises an error" do
+        expect { SetNameToDowncase.value }
+          .to raise_error(
+            ServiceActor::ArgumentError,
+            "The \"name\" input on \"SetNameToDowncase\" is missing",
+          )
+      end
+    end
+
+    context "when playing several actors" do
+      it "returns the result of the last actor" do
+        expect(PlayActors.value(value: 1)).to eq(3)
+      end
+
+      context "when not providing arguments" do
+        it "uses defaults from the inner actors" do
+          expect(PlayActors.value).to eq(2)
+        end
+      end
+    end
+
+    context "when playing actors and lambdas" do
+      it "calls the actors and lambdas in order and returns the final value" do
+        expect(PlayLambdas.value).to eq("jim number 4")
+      end
+    end
+
+    context "when playing actors and symbols" do
+      it "calls the actors and symbols in order and returns the final value" do
+        expect(PlayInstanceMethods.value).to eq("jim number 4")
+      end
+    end
+
+    context "when using `play` several times" do
+      it "shares the result between actors and returns the final value" do
+        expect(PlayMultipleTimes.value(value: 1)).to eq(3)
+      end
+    end
+
+    context "when using `play` with conditions" do
+      it "does not trigger actors with conditions and returns the final value" do
+        expect(PlayMultipleTimesWithConditions.value).to eq(3)
+      end
+    end
+
+    context "when using `play` with evaluated conditions" do
+      let(:output) do
+        PlayMultipleTimesWithEvaluatedConditions.value(callable: callable)
+      end
+      let(:callable) { -> {} }
+
+      before do
+        allow(callable).to receive(:call).and_return(true)
+      end
+
+      it "does not evaluate conditions multiple times" do
+        expect(output).to eq(4)
+        expect(callable).to have_received(:call).once
+      end
+    end
+
+    context "when playing several actors and one fails" do
+      let(:actor) { ServiceActor::Result.new(value: 0) }
+
+      it "raises with the message" do
+        expect { FailPlayingActionsWithRollback.value(actor) }
+          .to raise_error(ServiceActor::Failure, "Ouch")
+      end
+    end
+
+    context "when playing actors and alias_input" do
+      it "calls the actors and can be referenced by alias" do
+        expect(PlayAliasInput.value).to eq("jim number 1")
+      end
+    end
+
+    context "when value'd with a matching condition" do
+      context "when normal mode" do
+        it "suceeds" do
+          expect(SetNameWithInputCondition.value(name: "joe")).to eq("JOE")
+        end
+      end
+
+      context "when advanced mode" do
+        it "suceeds" do
+          expect(SetNameWithInputConditionAdvanced.value(name: "joe"))
+            .to eq("JOE")
+        end
+      end
+    end
+
+    context "when value'd with the wrong condition" do
+      context "when normal mode" do
+        it "raises" do
+          expected_error =
+            "The \"name\" input on \"SetNameWithInputCondition\" " \
+              "must \"be_lowercase\" but was \"42\""
+
+          expect { SetNameWithInputCondition.value(name: "42") }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+
+      context "when advanced mode" do
+        it "raises" do
+          expected_error = "Failed to apply `be_lowercase`"
+
+          expect { SetNameWithInputConditionAdvanced.value(name: "42") }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+    end
+
+    context "when value'd with an error in the code" do
+      describe "and type is first" do
+        context "when advanced mode" do
+          let(:expected_message) do
+            "The \"per_page\" input on " \
+              "\"ExpectedFailInMustWhenTypeIsFirstAdvanced\" must be " \
+              "of type \"Integer\" but was \"String\""
+          end
+
+          it "raises" do
+            expect do
+              ExpectedFailInMustWhenTypeIsFirstAdvanced.value(per_page: "6")
+            end.to raise_error(ServiceActor::ArgumentError, expected_message)
+          end
+        end
+      end
+
+      describe "and type is last" do
+        context "when advanced mode" do
+          let(:expected_message) do
+            "The \"per_page\" input on " \
+              "\"ExpectedFailInMustWhenTypeIsLastAdvanced\" has an error " \
+              "in the code inside \"be_in_range\": " \
+              "[ArgumentError] comparison of String with 3 failed"
+          end
+
+          it "raises" do
+            expect do
+              ExpectedFailInMustWhenTypeIsLastAdvanced.value(per_page: "6")
+            end.to raise_error(ServiceActor::ArgumentError, expected_message)
+          end
+        end
+      end
+    end
+
+    context "when value'd with the wrong type of argument" do
+      let(:expected_message) do
+        "The \"name\" input on \"SetNameToDowncase\" must be of " \
+          "type \"String\" but was \"Integer\""
+      end
+
+      it "raises" do
+        expect { SetNameToDowncase.value(name: 1) }
+          .to raise_error(ServiceActor::ArgumentError, expected_message)
+      end
+    end
+
+    context "when a type is defined but the argument is nil" do
+      let(:expected_message) do
+        'The "name" input on "SetNameToDowncase" does not allow nil values'
+      end
+
+      it "raises" do
+        expect { SetNameToDowncase.value(name: nil) }
+          .to raise_error(ServiceActor::ArgumentError, expected_message)
+      end
+    end
+
+    context "when called with a type as a string instead of a class" do
+      it "succeeds" do
+        expect(DoubleWithTypeAsString.value(value: 2.0)).to eq(4.0)
+      end
+
+      context "when normal mode" do
+        it "does not allow other types" do
+          expected_error =
+            "The \"value\" input on \"DoubleWithTypeAsString\" must " \
+              "be of type \"Integer, Float\" but was \"String\""
+          expect { DoubleWithTypeAsString.value(value: "2.0") }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+
+      context "when advanced mode" do
+        it "does not allow other types" do
+          expected_error =
+            "Wrong type `String` for `value`. Expected: `Integer, Float`"
+          expect { DoubleWithTypeAsStringAdvanced.value(value: "2.0") }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+    end
+
+    context "when disallowing nil on an input" do
+      context "when normal mode" do
+        context "when given the input" do
+          it "does not fail" do
+            expect(DisallowNilOnInput.value(name: "Jim")).to be_nil
+          end
+        end
+
+        context "without the input" do
+          it "fails" do
+            expected_error =
+              "The \"name\" input on \"DisallowNilOnInput\" does not " \
+                "allow nil values"
+
+            expect { DisallowNilOnInput.value(name: nil) }
+              .to raise_error(ServiceActor::ArgumentError, expected_error)
+          end
+        end
+      end
+
+      context "when advanced mode" do
+        context "when given the input" do
+          it "does not fail" do
+            expect(DisallowNilOnInputAdvanced.value(name: "Jim")).to be_nil
+          end
+        end
+
+        context "without the input" do
+          it "fails" do
+            expected_error = "The value `name` cannot be empty"
+
+            expect { DisallowNilOnInputAdvanced.value(name: nil) }
+              .to raise_error(ServiceActor::ArgumentError, expected_error)
+          end
+        end
+      end
+    end
+
+    context "when disallowing nil on an output" do
+      context "when set correctly" do
+        it "succeeds" do
+          expect(DisallowNilOnOutput.value).to be "Jim"
+        end
+      end
+
+      context "without the output" do
+        it "fails" do
+          expected_error =
+            "The \"name\" output on \"DisallowNilOnOutput\" " \
+              "does not allow nil values"
+
+          expect { DisallowNilOnOutput.value(test_without_output: true) }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+    end
+
+    context "when inheriting" do
+      it "calls both the parent and child" do
+        expect(InheritFromIncrementValue.value(value: 0)).to eq(2)
+      end
+    end
+
+    context "when inheriting from play" do
+      it "calls both the parent and child" do
+        expect(InheritFromPlay.value(value: 0)).to eq(3)
+      end
+    end
+
+    context "when playing interactors" do
+      it "succeeds" do
+        expect(PlayInteractor.value(value: 5).value).to eq(5 + 2)
+      end
+    end
+
+    context "when using advanced mode with checks and not adding message key" do
+      context "when using inclusion check" do
+        let(:expected_alert) do
+          'The "provider" input must be included ' \
+            'in ["MANGOPAY", "PayPal", "Stripe"] on ' \
+            '"PayWithProviderAdvancedNoMessage" ' \
+            'instead of "Paypal2"'
+        end
+
+        it "returns the default message" do
+          expect { PayWithProviderAdvancedNoMessage.value(provider: "Paypal2") }
+            .to raise_error(ServiceActor::ArgumentError, expected_alert)
+        end
+      end
+
+      context "when using type check" do
+        let(:expected_error) do
+          "The \"name\" input on \"CheckTypeAdvanced\" must " \
+            "be of type \"String\" but was \"Integer\""
+        end
+
+        it "returns the default message" do
+          expect { CheckTypeAdvanced.value(name: 2) }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+
+      context "when using must check" do
+        let(:expected_error) do
+          "The \"num\" input on \"CheckMustAdvancedNoMessage\" " \
+            "must \"be_smaller\" " \
+            "but was 6"
+        end
+
+        it "returns the default message" do
+          expect { CheckMustAdvancedNoMessage.value(num: 6) }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+
+      context "when using nil check" do
+        let(:expected_error) do
+          "The \"name\" input on \"CheckNilAdvancedNoMessage\" " \
+            "does not allow nil values"
+        end
+
+        it "returns the default message" do
+          expect { CheckNilAdvancedNoMessage.value(name: nil) }
+            .to raise_error(ServiceActor::ArgumentError, expected_error)
+        end
+      end
+    end
+
+    context "with unset output and allow_nil: true" do
+      it "does not fail" do
+        expect(WithUnsetOutput.value).to be_nil
       end
     end
   end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -5,44 +5,44 @@ RSpec.describe Actor do
     before { allow(Kernel).to receive(:warn).with(kind_of(String)) }
   end
 
-  describe "#output_of" do
+  describe "#value" do
     context "when fail! is not called" do
-      let(:output) { DoNothing.output_of }
+      let(:output) { DoNothing.value }
 
       it { expect(output).to be_nil }
     end
 
     context "when fail! is called" do
       it "raises the error message" do
-        expect { FailWithError.output_of }
+        expect { FailWithError.value }
           .to raise_error(ServiceActor::Failure, "Ouch")
       end
 
       context "when a custom class is specified" do
         it "raises the error message" do
-          expect { FailWithErrorWithCustomFailureClass.output_of }
+          expect { FailWithErrorWithCustomFailureClass.value }
             .to raise_error(MyCustomFailure, "Ouch")
         end
       end
     end
 
-    context "when an actor updates the context using output_of" do
+    context "when an actor updates the context using value" do
       it "returns the value of the context change" do
-        output = AddNameToContext.output_of
+        output = AddNameToContext.value
         expect(output).to eq("Jim")
       end
     end
 
-    context "when an actor updates the context with a hash using output_of" do
+    context "when an actor updates the context with a hash using value" do
       it "returns the hash value of the context change" do
-        output = AddHashToContext.output_of
+        output = AddHashToContext.value
         expect(output).to eq(name: "Jim")
       end
     end
 
     context "when an actor uses a method named after the input" do
       it "returns what is assigned to the context" do
-        output = SetNameToDowncase.output_of(name: "JIM")
+        output = SetNameToDowncase.value(name: "JIM")
         expect(output).to eq("jim")
       end
     end
@@ -51,27 +51,27 @@ RSpec.describe Actor do
       it "returns the value of the context" do
         actor = ServiceActor::Result.new(name: "Jim")
 
-        expect(AddNameToContext.output_of(actor)).to eq("Jim")
+        expect(AddNameToContext.value(actor)).to eq("Jim")
       end
     end
 
     context "when an actor changes a value" do
       it "returns the updated value" do
-        expect(IncrementValue.output_of(value: 1)).to eq(2)
+        expect(IncrementValue.value(value: 1)).to eq(2)
       end
     end
 
     context "when an input has a default" do
       it "can use it" do
-        expect(AddGreetingWithDefault.output_of).to eq("Hello, world!")
+        expect(AddGreetingWithDefault.value).to eq("Hello, world!")
       end
 
       it "is overridden by values added to call" do
-        expect(AddGreetingWithDefault.output_of(name: "Jim")).to eq("Hello, Jim!")
+        expect(AddGreetingWithDefault.value(name: "Jim")).to eq("Hello, Jim!")
       end
 
       it "is overridden by values already in the context" do
-        output = AddGreetingWithDefault.output_of(
+        output = AddGreetingWithDefault.value(
           ServiceActor::Result.new(name: "jim"),
         )
         expect(output).to eq("Hello, jim!")
@@ -80,16 +80,16 @@ RSpec.describe Actor do
 
     context "when an input has a default that is a hash" do
       it "can use it" do
-        expect(AddGreetingWithHashDefault.output_of).to eq("Hello, world!")
+        expect(AddGreetingWithHashDefault.value).to eq("Hello, world!")
       end
 
       it "is overridden by values added to call" do
-        output = AddGreetingWithHashDefault.output_of(options: {name: "Alice"})
+        output = AddGreetingWithHashDefault.value(options: {name: "Alice"})
         expect(output).to eq("Hello, Alice!")
       end
 
       it "is overridden by values already in the context" do
-        output = AddGreetingWithHashDefault.output_of(
+        output = AddGreetingWithHashDefault.value(
           ServiceActor::Result.new(options: {name: "Alice"}),
         )
         expect(output).to eq("Hello, Alice!")
@@ -98,21 +98,21 @@ RSpec.describe Actor do
 
     context "when an input has a lambda default" do
       it "can use it" do
-        output = AddGreetingWithLambdaDefault.output_of
+        output = AddGreetingWithLambdaDefault.value
         expect(output).to eq("Hello, world!")
       end
     end
 
     context "when a lambda default references other inputs" do
       it "adds the computed default" do
-        output = LambdaDefaultWithReference.output_of(old_project_id: 77_392)
+        output = LambdaDefaultWithReference.value(old_project_id: 77_392)
         expect(output).to eq(project_id: "77392.0")
       end
     end
 
     context "when an input has not been given" do
       it "raises an error" do
-        expect { SetNameToDowncase.output_of }
+        expect { SetNameToDowncase.value }
           .to raise_error(
             ServiceActor::ArgumentError,
             "The \"name\" input on \"SetNameToDowncase\" is missing",
@@ -122,43 +122,43 @@ RSpec.describe Actor do
 
     context "when playing several actors" do
       it "returns the result of the last actor" do
-        expect(PlayActors.output_of(value: 1)).to eq(3)
+        expect(PlayActors.value(value: 1)).to eq(3)
       end
 
       context "when not providing arguments" do
         it "uses defaults from the inner actors" do
-          expect(PlayActors.output_of).to eq(2)
+          expect(PlayActors.value).to eq(2)
         end
       end
     end
 
     context "when playing actors and lambdas" do
       it "calls the actors and lambdas in order and returns the final value" do
-        expect(PlayLambdas.output_of).to eq("jim number 4")
+        expect(PlayLambdas.value).to eq("jim number 4")
       end
     end
 
     context "when playing actors and symbols" do
       it "calls the actors and symbols in order and returns the final value" do
-        expect(PlayInstanceMethods.output_of).to eq("jim number 4")
+        expect(PlayInstanceMethods.value).to eq("jim number 4")
       end
     end
 
     context "when using `play` several times" do
       it "shares the result between actors and returns the final value" do
-        expect(PlayMultipleTimes.output_of(value: 1)).to eq(3)
+        expect(PlayMultipleTimes.value(value: 1)).to eq(3)
       end
     end
 
     context "when using `play` with conditions" do
       it "does not trigger actors with conditions and returns the final value" do
-        expect(PlayMultipleTimesWithConditions.output_of).to eq(3)
+        expect(PlayMultipleTimesWithConditions.value).to eq(3)
       end
     end
 
     context "when using `play` with evaluated conditions" do
       let(:output) do
-        PlayMultipleTimesWithEvaluatedConditions.output_of(callable: callable)
+        PlayMultipleTimesWithEvaluatedConditions.value(callable: callable)
       end
       let(:callable) { -> {} }
 
@@ -176,14 +176,14 @@ RSpec.describe Actor do
       let(:actor) { ServiceActor::Result.new(value: 0) }
 
       it "raises with the message" do
-        expect { FailPlayingActionsWithRollback.output_of(actor) }
+        expect { FailPlayingActionsWithRollback.value(actor) }
           .to raise_error(ServiceActor::Failure, "Ouch")
       end
     end
 
     context "when playing actors and alias_input" do
       it "calls the actors and can be referenced by alias" do
-        expect(PlayAliasInput.output_of).to eq("jim number 1")
+        expect(PlayAliasInput.value).to eq("jim number 1")
       end
     end
   end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -181,15 +181,6 @@ RSpec.describe Actor do
       end
     end
 
-    context "when playing several actors, one fails, one rolls back" do
-      # TODO: extend `output_of` with option to return the last valid rollback
-      # value instead of raising
-      it "raises with the message" do
-        expect { PlayErrorAndCatchItInRollback.output_of }
-          .to raise_error(ServiceActor::Failure, "Ouch")
-      end
-    end
-
     context "when playing actors and alias_input" do
       it "calls the actors and can be referenced by alias" do
         expect(PlayAliasInput.output_of).to eq("jim number 1")


### PR DESCRIPTION
As proposed in #151, this implements an `value` class method on actors. It returns the value of the actor's `call` method, or in the case of play actors, returns the value of the final actor's `call`. it otherwise functions exactly the same, respecting play conditions, validations, raising `ServiceActor::Failure` when an actor fails, etc.

```ruby
> IncrementValue.call(value: 1)
=> <ServiceActor::Result { :value => 2 }>

> IncrementValue.value(value: 1)
=> 2
```

This works by assigning the result of `call` to an internal result data key, `:_default_output`, then accessing that key for the return value. Because it is an internal key, I chose to filter it from `Result#to_h` so it is not visible to end users, though it is still technically there and accessible if you know about it.

I had to update the `_call` overrides of some of the feature concerns (`Checkable`, `Playable`) to maintain the return value chain of `super`, but the existing return values were not being used for anything.

I think the only addition might be support for returning the last rollback value, if desired. `Actor.result` allows access to the results of failed actors or play actor chains. Since `value` is more akin to `call` and raises when an actor in a play/rollback chain fails, one could add an option to not raise but instead return the last valid rollback value in the actor chain.

~~If this feature is desired, I'll finish extending the test suite to cover the rest of the `#call` scenarios and look at adding a `last_rollback_value` option.~~ Update: won't be going with this feature at this time, as mentioned here: https://github.com/sunny/actor/pull/152#discussion_r1559919379