### PR TITLE
Allow setting `failure?: true` on a result as well as `failure: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## unreleased
 
+Fix:
+- Allow setting `failure?: true` on a result as well as `failure: true` (#153)
+
 ## v3.8.1
 
 Fix:

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -59,7 +59,7 @@ class ServiceActor::Result < BasicObject
   end
 
   def failure?
-    data[:failure] || false
+    data[:failure] || data[:failure?] || false
   end
 
   def error

--- a/spec/service_actor/result_spec.rb
+++ b/spec/service_actor/result_spec.rb
@@ -173,4 +173,40 @@ RSpec.describe ServiceActor::Result do
       end
     end
   end
+
+  describe "#success?" do
+    it "returns true if the result is not a failure" do
+      expect(result).to be_a_success
+    end
+
+    it "returns false after a failure" do
+      expect { result.fail! }.to raise_error(ServiceActor::Failure)
+
+      expect(result).not_to be_a_success
+    end
+  end
+
+  describe "#failure?" do
+    it "returns false if the result is not a failure" do
+      expect(result).not_to be_a_failure
+    end
+
+    it "returns true after a failure" do
+      expect { result.fail! }.to raise_error(ServiceActor::Failure)
+
+      expect(result).to be_a_failure
+    end
+
+    it "returns true when setting failure" do
+      result = described_class.new(failure: true)
+
+      expect(result).to be_a_failure
+    end
+
+    it "returns true when setting a failure with a question mark" do
+      result = described_class.new(failure?: true)
+
+      expect(result).to be_a_failure
+    end
+  end
 end


### PR DESCRIPTION
Closes #153
