### PR TITLE
Allow Result to have indifferent access

### DIFF
--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -35,7 +35,7 @@ class ServiceActor::Result < BasicObject
   alias_method :blank?, :nil?
 
   def initialize(data = {})
-    @data = data.to_h.transform_keys { |key| convert_key(key) }
+    @data = data.to_h.transform_keys(&:to_sym)
   end
 
   def to_h
@@ -73,31 +73,31 @@ class ServiceActor::Result < BasicObject
   end
 
   def merge!(result)
-    data.merge!(result.transform_keys { |key| convert_key(key) })
+    data.merge!(result.transform_keys(&:to_sym))
 
     self
   end
 
   def key?(name)
-    name = convert_key(name)
+    name = name.to_sym
 
     to_h.key?(name)
   end
 
   def [](name)
-    name = convert_key(name)
+    name = name.to_sym
 
     data[name]
   end
 
   def []=(key, value)
-    key = convert_key(key)
+    key = key.to_sym
 
     data[key] = value
   end
 
   def delete!(key)
-    key = convert_key(key)
+    key = key.to_sym
 
     data.delete(key)
   end
@@ -116,10 +116,6 @@ class ServiceActor::Result < BasicObject
   private
 
   attr_reader :data
-
-  def convert_key(key)
-    key.to_sym
-  end
 
   # Key `_default_output` is an internal datum used by actor class
   # method `.valuable`. Don't expose it with the rest of the result.

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -7,7 +7,7 @@ class ServiceActor::Result < BasicObject
     def to_result(data)
       return data if data.is_a?(self)
 
-      new(data.to_h.transform_keys(&:to_sym))
+      new(data.to_h)
     end
   end
 
@@ -35,7 +35,7 @@ class ServiceActor::Result < BasicObject
   alias_method :blank?, :nil?
 
   def initialize(data = {})
-    @data = data.to_h
+    @data = data.to_h.transform_keys { |key| convert_key(key) }
   end
 
   def to_h
@@ -73,24 +73,32 @@ class ServiceActor::Result < BasicObject
   end
 
   def merge!(result)
-    data.merge!(result)
+    data.merge!(result.transform_keys { |key| convert_key(key) })
 
     self
   end
 
   def key?(name)
+    name = convert_key(name)
+
     to_h.key?(name)
   end
 
   def [](name)
+    name = convert_key(name)
+
     data[name]
   end
 
   def []=(key, value)
+    key = convert_key(key)
+
     data[key] = value
   end
 
   def delete!(key)
+    key = convert_key(key)
+
     data.delete(key)
   end
 
@@ -108,6 +116,10 @@ class ServiceActor::Result < BasicObject
   private
 
   attr_reader :data
+
+  def convert_key(key)
+    key.to_sym
+  end
 
   # Key `_default_output` is an internal datum used by actor class
   # method `.valuable`. Don't expose it with the rest of the result.

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -71,6 +71,18 @@ RSpec.describe Actor do
 
         expect(actor.name).to eq("jim")
       end
+
+      it "accepts implicit hashes" do
+        actor = SetNameToDowncase.call("name" => "ImplicitJim")
+
+        expect(actor.name).to eq("implicitjim")
+      end
+
+      it "accepts splatted hashes" do
+        actor = SetNameToDowncase.call(**{"name" => "SplattedJim"})
+
+        expect(actor.name).to eq("splattedjim")
+      end
     end
 
     context "when an actor changes a value" do

--- a/spec/service_actor/result_spec.rb
+++ b/spec/service_actor/result_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe ServiceActor::Result do
     expect(result.respond_to?(:name?)).to be true
   end
 
+  it "has indifferent access" do
+    result.name = "Sunny"
+
+    expect(result[:name]).to eq("Sunny")
+    expect(result["name"]).to eq("Sunny")
+  end
+
   describe ".instance_methods" do
     it "stays the same across supported Rubies" do # rubocop:disable RSpec/ExampleLength
       expect(described_class.instance_methods).to contain_exactly(


### PR DESCRIPTION
@sunny I pulled down the changes from #171, and found a couple more subtle failure points during my testing. If you pass an implicit hash with string keys, or splat in a hash with string keys you end up with the same results as before #171. 

I ended up just modifying Result to have a bit more parity with OpenStruct, since OpenStruct has indifferent key access.