### PR TITLE
Fix ServiceActor::Result presentation in IRB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Fixes:
 - Add `#hash` and `#instance_of?` to `ServiceActor::Result` (#168)
+- Fix "An error occurred when inspecting the object" - `ArgumentError` for `ServiceActor::Result` when using `IRB`
 
 ## v3.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Fixes:
 - Add `#hash` and `#instance_of?` to `ServiceActor::Result` (#168)
-- Fix "An error occurred when inspecting the object" - `ArgumentError` for `ServiceActor::Result` when using `IRB` (#174 )
+- Fix "An error occurred when inspecting the object" - `ArgumentError` for `ServiceActor::Result` when using `IRB` (#174)
 
 ## v3.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Fixes:
 - Add `#hash` and `#instance_of?` to `ServiceActor::Result` (#168)
-- Fix "An error occurred when inspecting the object" - `ArgumentError` for `ServiceActor::Result` when using `IRB`
+- Fix "An error occurred when inspecting the object" - `ArgumentError` for `ServiceActor::Result` when using `IRB` (#174 )
 
 ## v3.9.3
 

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -46,7 +46,11 @@ class ServiceActor::Result < BasicObject
     "<#{self.class.name} #{to_h}>"
   end
 
-  alias_method :pretty_print, :inspect
+  def pretty_print(pp)
+    pp.text "#<#{self.class.name} "
+    pp.pp to_h
+    pp.text ">"
+  end
 
   def fail!(failure_class = nil, result = {})
     if failure_class.nil? || failure_class.is_a?(::Hash)

--- a/spec/service_actor/result_spec.rb
+++ b/spec/service_actor/result_spec.rb
@@ -222,4 +222,20 @@ RSpec.describe ServiceActor::Result do
       expect(result).to be_a_failure
     end
   end
+
+  describe "#pretty_print" do
+    context "without nested attributes" do
+      it "correctly pretty prints the result" do
+        expect(PP.pp(result, +"")).to eq("#<ServiceActor::Result {}>\n")
+      end
+    end
+
+    context "with nested attributes" do
+      let(:result) { described_class.new(a: 1, b: "hello") }
+
+      it "correctly pretty prints the result" do
+        expect(PP.pp(result, +"")).to eq("#<ServiceActor::Result {:a=>1, :b=>\"hello\"}>\n")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
Using `ServiceActor` gem in `Rails 7.2`. Using the default `IRB` for `rails console`.
Ruby version: `3.3.4`

**Note**: The issue does not appear when using `pry`.

### Bug description
`IRB` reports the following error when working with `ServiceActor::Result` instances:

```ruby
ServiceActor::Result.new
# => An error occurred when inspecting the object: #<ArgumentError: wrong number of arguments (given 1, expected 0)> Result of Kernel#inspect: #<ServiceActor::Result:0x0000777bdb3ad0a8 @data={}>
```

### Explanation
`IRB` calls `pretty_print` under the hood, and passes it an argument (an instance of `PP` class). `pretty_print` was defined as an alias of `inspect` which does not accept any arguments.

### Solution
Implement `pretty_print` instance method in `ServiceActor::Result` that accepts an instance of `PP` and prints it in a consistent way.

```ruby
ServiceActor::Result.new
# => #<ServiceActor::Result {}>
```

### Progress
- [x] Fix `ServiceActor::Result` presentation in IRB
- [x] Confirm there's not regression with `pry`