### PR TITLE
Fix `ThreadSafety::DirChdir` rubocop issue

### DIFF
--- a/service_actor.gemspec
+++ b/service_actor.gemspec
@@ -28,9 +28,7 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    %x(git ls-files -z lib).split("\x0")
-  end
+  spec.files = IO.popen(%w[git ls-files -z lib], chdir: __dir__, err: IO::NULL) { |ls| ls.readlines("\x0", chomp: true) }
 
   spec.required_ruby_version = [">= 2.7"]
 

--- a/service_actor.gemspec
+++ b/service_actor.gemspec
@@ -28,7 +28,10 @@ Gem::Specification.new do |spec|
     README.md
   ]
 
-  spec.files = IO.popen(%w[git ls-files -z lib], chdir: __dir__, err: IO::NULL) { |ls| ls.readlines("\x0", chomp: true) }
+  files = %w[git ls-files -z lib]
+  spec.files = IO.popen(files, chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true)
+  end
 
   spec.required_ruby_version = [">= 2.7"]
 


### PR DESCRIPTION
I've recently implemented `ThreadSafety::DirChdir` cop ([ref](https://github.com/rubocop/rubocop-thread_safety/pull/36)) to track `Dir.chdir` calls. While it's completely safe in gemspec, it can be fixed easily by adopting [state-of-art gemspec template](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt#L28-L36) ([ref](https://github.com/rubygems/rubygems/commit/5583433dbb86671101e9ee9ec86d0644ada9c8e5))

```ruby
Dir.chdir(File.expand_path(__dir__)) { %x(git ls-files -z lib).split("\x0") } == IO.popen(%w[git ls-files -z lib], chdir: __dir__, err: IO::NULL) { |ls| ls.readlines("\x0", chomp: true) }
=> true
```