### PR TITLE
Add generic types support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Feature:
 - Allow `output` to accept procs as defaults. (#188)
+- Allow any object that responds to `===` to be used as a type. (#187)
 - Allow objects without `Kernel` inclusion to function with the `play` DSL. (#180)
 
 ## v3.9.4

--- a/lib/service_actor/checks/type_check.rb
+++ b/lib/service_actor/checks/type_check.rb
@@ -72,14 +72,14 @@ class ServiceActor::Checks::TypeCheck < ServiceActor::Checks::Base
 
     types, message = define_types_and_message
 
-    return if types.any? { |type| @given_type.is_a?(type) }
+    return if types.any? { |type| type === @given_type }
 
     add_argument_error(
       message,
       origin: @origin,
       input_key: @input_key,
       actor: @actor,
-      expected_type: types.join(", "),
+      expected_type: types.map(&:name).join(", "),
       given_type: @given_type.class,
     )
   end


### PR DESCRIPTION
NOTE: this is a proof-of-concept implementation of generic types, some discussion and documentation changes are required.

Before these changes, we used to verify value's type by checking if it is an instance of any of provided modules (usually classes). We can easily (and without breaking backward compatibility) generalize this behaviour and allow any object responding to `===` message to act as a type.

Using `===` is the most natural and generic way to organize API for type systems. Some homemade basic examples:

```ruby

class BooleanType
  class << self
    def ===(value)
      value.is_a?(TrueClass) || value.is_a?(FalseClass)
    end

    def name = "Boolean"
  end
end
```

```ruby

class InternedType
  class << self
    def ===(value)
      value.is_a?(Symbol) || value.is_a?(String)
    end

    def name = "Interned"
  end
end
```

```ruby

class GenericArray
  def initialize(generic_type)
    @generic_type = generic_type
  end

  class << self
    alias [] new
  end

  def ===(value)
    value.respond_to?(:all?) && value.all? { |value_item| @generic_type === value_item }
  end

  def name
    "[#{@generic_type}]"
  end
end

=begin
class UsersActor < ApplicationActor
  input :users, type: GenericArray[User]
end

UsersActor.call(users: [User.find(1), User.find(2)]) # => OK
UsersActor.call(users: [User.find(1), Animal.find(2)]) # => runtime error
=end
```

This API should make it relatively easy to adopt external type systems, like [literal] (https://github.com/joeldrapper/literal)

I believe we'll be able to close https://github.com/sunny/actor/issues/39 after this.

One minor probels is that some error messages seem weird with (some) generic types, e.g. in 3rd example it'd be

```ruby
"The "users" input on "TestActor" must be of type "GenericArray[Integer]" but was "Array"
```

we can mitigate this by making the error message more generic, for instance

```ruby
"The "users" input on "TestActor" does not satify the type "GenericArray[Integer]"
```