### PR TITLE
Allow `output` to accept procs as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## unreleased
 
 Feature:
+- Allow `output` to accept procs as defaults. (#188)
 - Allow objects without `Kernel` inclusion to function with the `play` DSL. (#180)
 
 ## v3.9.4

--- a/lib/service_actor/defaultable.rb
+++ b/lib/service_actor/defaultable.rb
@@ -43,25 +43,29 @@ module ServiceActor::Defaultable
           )
         end
 
-        default = input[:default]
-
-        if default.is_a?(Hash) && default[:is]
-          default_for_advanced_mode_with(result, key, default)
-        else
-          default_for_normal_mode_with(result, key, default)
-        end
+        apply_default_for_origin(key, input)
       end
 
-      self.class.outputs.each do |key, options|
-        unless result.key?(key)
-          result.send(:"#{key}=", options[:default])
-        end
+      self.class.outputs.each do |key, output|
+        next if result.key?(key)
+
+        apply_default_for_origin(key, output)
       end
 
       super
     end
 
     private
+
+    def apply_default_for_origin(origin_name, origin_options)
+      default = origin_options[:default]
+
+      if default.is_a?(Hash) && default[:is]
+        default_for_advanced_mode_with(result, origin_name, default)
+      else
+        default_for_normal_mode_with(result, origin_name, default)
+      end
+    end
 
     def default_for_normal_mode_with(result, key, default)
       result[key] = reify_default(result, default)

--- a/spec/examples/add_greeting_with_output_lambda_default.rb
+++ b/spec/examples/add_greeting_with_output_lambda_default.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddGreetingWithOutputLambdaDefault < Actor
+  input :name, default: "world", type: String
+
+  output :greeting, type: String
+  output :zero_arity_output_default, type: Integer, default: -> { 42 }
+  output :one_arity_output_default, type: String, default: -> actor { actor.name + "!" }
+  output :nested_lambda_default, type: Proc, default: -> { -> { 43 } }
+  output :complex_lambda_default, type: Integer, default: {
+    is: -> { 142 },
+    message: (lambda do |input_key, actor|
+      "Output \"#{input_key}\" is required"
+    end),
+  }
+
+  def call
+    self.greeting = "Hello, #{name}!"
+  end
+end


### PR DESCRIPTION
To fix a behaviour mismatch between `input` and `output` noted in https://github.com/sunny/actor/issues/184, this PR allows `output` to accept Procs (either with 0- or 1-arity) as defaults.

It's important to mention that output defaults will be evaluated (`call`'ed) eagerly, i.e. at the same time the inputs (or non-proc output defaults) are evaluated. It means that we will sometimes allocate new objects or reference some constants for outputs which will be re-assigned during actor's runtime. But I think that's consistent with how things worked before.

Another approach would be to assign non-procs output defaults before actor's runtime (to preserve backward compat) and proc defaults after it is played.