### PR TITLE
Emit a warning unless default value is a proc or an immutable object

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ inherit_gem:
   rubocop-lts: rubocop-lts.yml
 
 AllCops:
+  TargetRubyVersion: 3.0
   Exclude:
     - bin/rake
     - bin/rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Feature:
 - Drop Ruby MRI 2.7 support. (#194)
 - Add support for JRuby. (#193)
+- Emit a warning unless default value is a proc or an immutable object. (#191)
 - Allow `output` to accept procs as defaults. (#188)
 - Allow any object that responds to `===` to be used as a type. (#187)
 - Allow objects without `Kernel` inclusion to function with the `play` DSL. (#180)

--- a/README.md
+++ b/README.md
@@ -338,6 +338,33 @@ actor = BuildGreeting.call(name: "Siobhan", adjective: "elegant")
 actor.greeting # => "Have an elegant week, Siobhan!"
 ```
 
+While lambdas are the preferred way to specify defaults, you can also provide
+a default value without using lambdas by using an immutable object.
+
+```rb
+# frozen_string_literal: true
+
+class ExampleActor < Actor
+  input :options, default: {
+    names: {male: "Iaroslav", female: "Anna"}.freeze,
+    country_codes: %w[gb ru].freeze
+  }.freeze
+end
+```
+
+Note that default values might be mutated if the values returned by the lambda
+are references to mutable objects, e.g.
+
+```rb
+class ExampleActor < Actor
+  input :options, default: -> { Registry::DEFAULT_OPTIONS } # `Registry::DEFAULT_OPTIONS` is not frozen
+
+  def call
+    options[:names] = nil
+  end
+end
+```
+
 ### Allow nil
 
 By default inputs accept `nil` values. To raise an error instead:

--- a/lib/service_actor/arguments_validator.rb
+++ b/lib/service_actor/arguments_validator.rb
@@ -16,4 +16,13 @@ module ServiceActor::ArgumentsValidator
 
     raise ArgumentError, "Expected #{value} to be a subclass of Exception"
   end
+
+  def validate_default_value(value, origin_type:, origin_name:, actor:)
+    return if value.is_a?(Proc) || !defined?(Ractor.shareable?) || Ractor.shareable?(value)
+
+    ::Kernel.warn(
+      "DEPRECATED: Actor `#{actor}` has #{origin_type} `#{origin_name}` with default " \
+        "which is not a Proc or an immutable object.",
+    )
+  end
 end

--- a/lib/service_actor/attributable.rb
+++ b/lib/service_actor/attributable.rb
@@ -26,6 +26,10 @@ module ServiceActor::Attributable
         name, origin: :input
       )
 
+      ServiceActor::ArgumentsValidator.validate_default_value(
+        arguments[:default], actor: self, origin_type: :input, origin_name: name
+      )
+
       inputs[name] = arguments
 
       define_method(name) do
@@ -45,6 +49,10 @@ module ServiceActor::Attributable
     def output(name, **arguments)
       ServiceActor::ArgumentsValidator.validate_origin_name(
         name, origin: :output
+      )
+
+      ServiceActor::ArgumentsValidator.validate_default_value(
+        arguments[:default], actor: self, origin_type: :output, origin_name: name
       )
 
       outputs[name] = arguments

--- a/spec/examples/add_greeting_with_hash_default.rb
+++ b/spec/examples/add_greeting_with_hash_default.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AddGreetingWithHashDefault < Actor
-  input :options, default: {name: "world"}
+  input :options, default: -> { {name: "world"} }
   output :greeting, type: String
 
   def call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ require "bundler/setup"
 require "service_actor"
 require "pry"
 
+Dir["#{__dir__}/support/**/*.rb"].each { |path| require path }
+
 # Autoload examples
 loader = Zeitwerk::Loader.new
 loader.push_dir(File.expand_path("examples", __dir__))
@@ -25,4 +27,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+end
+
+def engine_mri?
+  RUBY_ENGINE == "ruby"
 end

--- a/spec/support/shared_contexts/with_mocked_kernel_warn.rb
+++ b/spec/support/shared_contexts/with_mocked_kernel_warn.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with mocked `Kernel.warn` method" do
+  before { allow(Kernel).to receive(:warn).with(kind_of(String)) }
+end


### PR DESCRIPTION
Resolves https://github.com/sunny/actor/issues/184

This PR adds experimental support for detecting mutable non-proc default values using the `Ractor.shareable?` API.

By the way, given that we now use platform-dependent code we might want to add JRuby to CI matrix?