### PR TITLE
Drop obsolete `ServiceActor::Checks::Base.applicable_to_origin?` method

### DIFF
--- a/lib/service_actor/checkable.rb
+++ b/lib/service_actor/checkable.rb
@@ -31,10 +31,9 @@ module ServiceActor::Checkable
 
     # rubocop:disable Metrics/MethodLength
     def service_actor_checks_for(origin)
-      check_classes = CHECK_CLASSES.select { _1.applicable_to_origin?(origin) }
       self.class.public_send(:"#{origin}s").each do |input_key, input_options|
         input_options.each do |check_name, check_conditions|
-          check_classes.each do |check_class|
+          CHECK_CLASSES.each do |check_class|
             argument_errors = check_class.check(
               check_name: check_name,
               origin: origin,

--- a/lib/service_actor/checks/base.rb
+++ b/lib/service_actor/checks/base.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 class ServiceActor::Checks::Base
-  class << self
-    def applicable_to_origin?(_origin)
-      true
-    end
-  end
-
   def initialize
     @argument_errors = []
   end


### PR DESCRIPTION
Previously it was used to skip default check on outputs. Since removal of `DefaultCheck` (https://github.com/sunny/actor/pull/145) it is obsolete.