### PR TITLE
Disallow inputs called `result`, `call`, `fail!` or `rollback` to avoid stack overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Features:
 - The `inclusion:` and `must:` checks are ignored on nil values when
   `allow_nil: true`. (#202)
 
+Fixes:
+- Disallow inputs called `result`, `call`, `fail!` or `rollback` to avoid stack
+  overflow exceptions. (#206)
+
 ## v4.0.0
 
 Breaking change:

--- a/lib/service_actor/arguments_validator.rb
+++ b/lib/service_actor/arguments_validator.rb
@@ -4,8 +4,11 @@ module ServiceActor::ArgumentsValidator
   module_function
 
   def validate_origin_name(name, origin:)
-    return if name.to_sym == :error
-    return unless ServiceActor::Result.instance_methods.include?(name.to_sym)
+    name = name.to_sym
+    return if name == :error
+
+    methods = ServiceActor::Core.instance_methods + ServiceActor::Result.instance_methods
+    return unless methods.include?(name)
 
     raise ArgumentError,
           "#{origin} `#{name}` overrides `ServiceActor::Result` instance method"

--- a/lib/service_actor/attributable.rb
+++ b/lib/service_actor/attributable.rb
@@ -23,11 +23,15 @@ module ServiceActor::Attributable
 
     def input(name, **arguments)
       ServiceActor::ArgumentsValidator.validate_origin_name(
-        name, origin: :input
+        name,
+        origin: :input,
       )
 
       ServiceActor::ArgumentsValidator.validate_default_value(
-        arguments[:default], actor: self, origin_type: :input, origin_name: name
+        arguments[:default],
+        actor: self,
+        origin_type: :input,
+        origin_name: name,
       )
 
       inputs[name] = arguments
@@ -48,11 +52,15 @@ module ServiceActor::Attributable
 
     def output(name, **arguments)
       ServiceActor::ArgumentsValidator.validate_origin_name(
-        name, origin: :output
+        name,
+        origin: :output,
       )
 
       ServiceActor::ArgumentsValidator.validate_default_value(
-        arguments[:default], actor: self, origin_type: :output, origin_name: name
+        arguments[:default],
+        actor: self,
+        origin_type: :output,
+        origin_name: name,
       )
 
       outputs[name] = arguments

--- a/spec/service_actor/arguments_validator_spec.rb
+++ b/spec/service_actor/arguments_validator_spec.rb
@@ -1,6 +1,42 @@
 # frozen_string_literal: true
 
 RSpec.describe ServiceActor::ArgumentsValidator do
+  describe "input on Actor" do
+    let(:actor_class) { Class.new(Actor) { input :age } }
+
+    it { expect(actor_class.call(age: 40).age).to eq(40) }
+
+    context "when called result" do
+      let(:actor_class) { Class.new(Actor) { input :result } }
+
+      it { expect { actor_class.call(result: 1) }.to raise_error(ArgumentError) }
+    end
+
+    context "when called call" do
+      let(:actor_class) { Class.new(Actor) { input :call } }
+
+      it { expect { actor_class.call(call: 1) }.to raise_error(ArgumentError) }
+    end
+
+    context "when called fail!" do
+      let(:actor_class) { Class.new(Actor) { input :fail! } }
+
+      it { expect { actor_class.call(fail!: 1) }.to raise_error(ArgumentError) }
+    end
+
+    context "when called rollback" do
+      let(:actor_class) { Class.new(Actor) { input :rollback } }
+
+      it { expect { actor_class.call(rollback: 1) }.to raise_error(ArgumentError) }
+    end
+
+    context "when called error" do
+      let(:actor_class) { Class.new(Actor) { input :error } }
+
+      it { expect(actor_class.call(error: 42).error).to eq(42) }
+    end
+  end
+
   describe ".validate_origin_name" do
     it "raises on name collision" do
       expect do


### PR DESCRIPTION
Closes #206
