### PR TITLE
Store failure exception with cause on result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Breaking changes:
 - Invoking undefined methods on `ServiceActor::Result` now raises an error (previously it only issued a warning). (#213)
 
+Feature:
+- Make raised exception available as `ServiceActor::Result#exception`. (#220)
+
 ## v5.0.0
 
 Breaking changes:

--- a/lib/service_actor/failable.rb
+++ b/lib/service_actor/failable.rb
@@ -38,7 +38,7 @@ module ServiceActor::Failable
     def _call
       super
     rescue *self.class.fail_ons => e
-      fail!(error: e.message)
+      fail!(error: e.message, exception: e)
     end
   end
 end

--- a/lib/service_actor/result.rb
+++ b/lib/service_actor/result.rb
@@ -62,7 +62,17 @@ class ServiceActor::Result < BasicObject
     data.merge!(result)
     data[:failure] = true
 
-    ::Kernel.raise failure_class, self
+    cause = data.delete(:exception)
+    exception = failure_class.new(self)
+    data[:exception] = exception
+
+    ::Kernel.raise exception unless cause
+
+    begin
+      ::Kernel.raise cause
+    rescue
+      ::Kernel.raise exception
+    end
   end
 
   def success?
@@ -75,6 +85,10 @@ class ServiceActor::Result < BasicObject
 
   def error
     data[:error] || nil
+  end
+
+  def exception
+    data[:exception] || nil
   end
 
   def merge!(result)

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -1825,6 +1825,8 @@ RSpec.describe Actor do
         expect(actor.error).to match(
           /\AThe "name" input on ".+" must be of type "String" but was "Integer"\z/,
         )
+        expect(actor.exception).to be_a ServiceActor::Failure
+        expect(actor.exception.cause).to be_a ServiceActor::ArgumentError
       end
     end
 

--- a/spec/service_actor/result_spec.rb
+++ b/spec/service_actor/result_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe ServiceActor::Result do
         :delete!,
         :equal?,
         :error,
+        :exception,
         :fail!,
         :failure?,
         :hash,
@@ -172,6 +173,26 @@ RSpec.describe ServiceActor::Result do
       result.error = "Something went wrong"
 
       expect(result.error).to eq("Something went wrong")
+    end
+  end
+
+  describe "#exception" do
+    it "returns the raised exception" do
+      expect { result.fail!(error: "Something went wrong!") }
+        .to raise_error(ServiceActor::Failure)
+      exception = result.exception
+      expect(exception).to be_a ServiceActor::Failure
+      expect(exception.message).to eq "Something went wrong!"
+    end
+  end
+
+  describe "#exception cause" do
+    it "returns exception passed to fail!" do
+      cause = ArgumentError.new
+      expect { result.fail!(exception: cause) }
+        .to raise_error(ServiceActor::Failure)
+      expect(result.exception).to be_a ServiceActor::Failure
+      expect(result.exception.cause).to be cause
     end
   end
 


### PR DESCRIPTION
Hello! 👋

The goal of this change is to make raised exceptions available to the caller of `Actor#result`. Additionally, exceptions rescued with `fail_on` are captured as the `cause` of the configured failure class.

I'm not too attached to the implementation here, so I'd appreciate your thoughts! But I found this necessary for some work I'm doing and had to patch `ServiceActor::Failable`.