### PR TITLE
CI: test on supported JRuby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0", head, jruby-10.0.0.1]
+        ruby: ["3.2", "3.3", "3.4", "4.0", head, jruby-10.0, jruby-10.1]
 
     env:
       # Released Bundler is broken on ruby-head due to ruby/ruby#16895.


### PR DESCRIPTION
Instead of testing on patch-pinned version of JRuby (`jruby-10.0.0.1`), I'd like to propose consistently testing on all the two non-EOLed versions, pinned to minor

ref: https://endoflife.date/jruby

NB: 9.4 is excluded since we don't support corresponding MRI 3.1