### PR TITLE
CI: prevent job duplicates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 env:
   RUBYOPT: --enable-frozen-string-literal --debug-frozen-string-literal


### PR DESCRIPTION
When running CI against forked repo, the jobs are doubled. The canonical way to solve it is to scope push-events to the main branch.